### PR TITLE
fix: the `μ` used in the tests was a different unicode symbol then th…

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -153,7 +153,7 @@ from custom_components.openplantbook.uploader import get_supported_state_value
                 state="500",
                 attributes={
                     "device_class": "conductivity",
-                    "unit_of_measurement": "µS/cm",
+                    "unit_of_measurement": "μS/cm",
                 },
             ),
             500,
@@ -165,7 +165,7 @@ from custom_components.openplantbook.uploader import get_supported_state_value
                 state="5000",
                 attributes={
                     "device_class": "conductivity",
-                    "unit_of_measurement": "µS/cm",
+                    "unit_of_measurement": "μS/cm",
                 },
             ),
             5000,


### PR DESCRIPTION
fix: the `μ` used in the tests was a different unicode symbol then the one from the HAS declaration (homeassistant.const )for conductivity

μ	Greek small letter mu	U+03BC	GREEK SMALL LETTER MU
µ	Micro sign	U+00B5	MICRO SIGN

Test runs now as intended.