### PR TITLE
Fix all ruff and black linting issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,15 @@ select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
     "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
 ]
 ignore = [
     "E501",   # line too long (handled by black)
-    "E722",   # bare except (existing code pattern)
-    "F401",   # imported but unused (many re-exports in __init__)
-    "F541",   # f-string without placeholders
-    "F841",   # local variable assigned but never used
 ]
+
+[tool.ruff.lint.isort]
+known-first-party = ["custom_components.openplantbook"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["E402"]  # Allow imports not at top of file in tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 


### PR DESCRIPTION
## Summary
- Sort all imports with isort
- Convert %-style string formatting to f-strings
- Remove f-string prefix where no placeholders used
- Remove unused imports
- Replace bare `except` with specific exception types
- Enable stricter ruff rules matching plant repo

## Changes
- `__init__.py` - Sorted imports, removed unused imports
- `config_flow.py` - Sorted imports, removed unused exception variables
- `uploader.py` - Sorted imports, converted % formatting to f-strings, fixed bare excepts
- `pyproject.toml` - Added isort and pyupgrade rules
- `tests/` - Removed unused imports

## Test plan
- [x] All 37 tests pass
- [x] ruff check passes
- [x] black formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)