### PR TITLE
Improve test coverage from 49% to 70%

### DIFF
--- a/custom_components/openplantbook/uploader.py
+++ b/custom_components/openplantbook/uploader.py
@@ -146,6 +146,7 @@ async def plant_data_upload(hass, entry, call=None) -> dict[str, Any] | None:
 
     entity_reg = entity_registry.async_get(hass)
     jts_doc = JtsDocument()
+    latest_data = None  # Track latest upload timestamp across all plants
 
     # Go through plant devices one by one and extract corresponding sensors' states
     for i in plant_devices:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,255 @@
+"""Tests for openplantbook config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from openplantbook_sdk import MissingClientIdOrSecret
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openplantbook.const import (
+    DEFAULT_IMAGE_PATH,
+    DOMAIN,
+    FLOW_DOWNLOAD_IMAGES,
+    FLOW_DOWNLOAD_PATH,
+    FLOW_UPLOAD_DATA,
+    FLOW_UPLOAD_HASS_LOCATION_COORD,
+    FLOW_UPLOAD_HASS_LOCATION_COUNTRY,
+)
+
+
+class TestConfigFlow:
+    """Tests for the config flow."""
+
+    async def test_user_step_shows_form(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that the user step shows the form."""
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {}
+
+    async def test_user_step_invalid_auth(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that invalid auth shows error."""
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(
+                side_effect=MissingClientIdOrSecret("Invalid credentials")
+            )
+            mock_api_class.return_value = mock_api
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_CLIENT_ID: "invalid_id",
+                    CONF_CLIENT_SECRET: "invalid_secret",
+                },
+            )
+
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "user"
+            assert result["errors"] == {CONF_CLIENT_ID: "invalid_auth"}
+
+    async def test_user_step_cannot_connect(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that connection error shows error."""
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(
+                side_effect=ConnectionError("Cannot connect")
+            )
+            mock_api_class.return_value = mock_api
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_CLIENT_ID: "test_id",
+                    CONF_CLIENT_SECRET: "test_secret",
+                },
+            )
+
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "user"
+            assert result["errors"] == {"base": "cannot_connect"}
+
+    async def test_user_step_success_goes_to_upload(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that valid credentials proceed to upload step."""
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(return_value="test_token")
+            mock_api_class.return_value = mock_api
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_CLIENT_ID: "valid_id",
+                    CONF_CLIENT_SECRET: "valid_secret",
+                },
+            )
+
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "upload"
+
+    async def test_upload_step_creates_entry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that upload step creates the config entry."""
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(return_value="test_token")
+            mock_api_class.return_value = mock_api
+
+            # Start flow
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+
+            # Complete user step
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_CLIENT_ID: "valid_id",
+                    CONF_CLIENT_SECRET: "valid_secret",
+                },
+            )
+
+            # Complete upload step
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    FLOW_UPLOAD_DATA: True,
+                    FLOW_UPLOAD_HASS_LOCATION_COUNTRY: False,
+                    FLOW_UPLOAD_HASS_LOCATION_COORD: False,
+                },
+            )
+
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+            assert result["title"] == "Openplantbook API"
+            assert result["data"][CONF_CLIENT_ID] == "valid_id"
+            assert result["data"][CONF_CLIENT_SECRET] == "valid_secret"
+            assert result["options"][FLOW_UPLOAD_DATA] is True
+
+
+class TestOptionsFlow:
+    """Tests for the options flow."""
+
+    async def test_options_flow_init(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_api: MagicMock,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test options flow initialization."""
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+    async def test_options_flow_save(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_api: MagicMock,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test saving options."""
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                FLOW_UPLOAD_DATA: True,
+                FLOW_UPLOAD_HASS_LOCATION_COUNTRY: True,
+                FLOW_UPLOAD_HASS_LOCATION_COORD: False,
+                FLOW_DOWNLOAD_IMAGES: False,
+                FLOW_DOWNLOAD_PATH: DEFAULT_IMAGE_PATH,
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"][FLOW_UPLOAD_DATA] is True
+        assert result["data"][FLOW_UPLOAD_HASS_LOCATION_COUNTRY] is True
+
+    async def test_options_flow_invalid_download_path(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_api: MagicMock,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test that invalid download path shows error."""
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                FLOW_UPLOAD_DATA: False,
+                FLOW_UPLOAD_HASS_LOCATION_COUNTRY: False,
+                FLOW_UPLOAD_HASS_LOCATION_COORD: False,
+                FLOW_DOWNLOAD_IMAGES: True,
+                FLOW_DOWNLOAD_PATH: "/nonexistent/path/that/does/not/exist",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+        assert result["errors"] == {FLOW_DOWNLOAD_PATH: "invalid_path"}
+
+    async def test_options_flow_download_disabled_ignores_path(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_api: MagicMock,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test that download path is ignored when download is disabled."""
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                FLOW_UPLOAD_DATA: False,
+                FLOW_UPLOAD_HASS_LOCATION_COUNTRY: False,
+                FLOW_UPLOAD_HASS_LOCATION_COORD: False,
+                FLOW_DOWNLOAD_IMAGES: False,
+                FLOW_DOWNLOAD_PATH: "/nonexistent/path",
+            },
+        )
+
+        # Should succeed because download is disabled
+        assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from homeassistant.core import HomeAssistant
+from openplantbook_sdk import MissingClientIdOrSecret
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openplantbook.const import (
@@ -16,6 +18,7 @@ from custom_components.openplantbook.const import (
     OPB_SERVICE_SEARCH,
     OPB_SERVICE_UPLOAD,
 )
+from custom_components.openplantbook.plantbook_exception import OpenPlantbookException
 
 
 class TestIntegrationSetup:
@@ -215,3 +218,177 @@ class TestCleanCacheService:
 
         # Cache should be empty
         assert "monstera deliciosa" not in hass.data[DOMAIN][ATTR_SPECIES]
+
+
+class TestSearchServiceErrors:
+    """Tests for search service error handling."""
+
+    async def test_search_service_missing_alias(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test search service raises error when alias is missing."""
+        with pytest.raises(OpenPlantbookException):
+            await hass.services.async_call(
+                DOMAIN,
+                OPB_SERVICE_SEARCH,
+                {},  # No alias provided
+                blocking=True,
+            )
+
+    async def test_search_service_api_error(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test search service handles API errors."""
+        mock_openplantbook_api.async_plant_search = AsyncMock(
+            side_effect=MissingClientIdOrSecret("Invalid credentials")
+        )
+
+        with pytest.raises(MissingClientIdOrSecret):
+            await hass.services.async_call(
+                DOMAIN,
+                OPB_SERVICE_SEARCH,
+                {"alias": "monstera"},
+                blocking=True,
+            )
+
+
+class TestGetPlantServiceErrors:
+    """Tests for get plant service error handling."""
+
+    async def test_get_plant_missing_species(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test get plant raises error when species is missing."""
+        with pytest.raises(OpenPlantbookException):
+            await hass.services.async_call(
+                DOMAIN,
+                OPB_SERVICE_GET,
+                {},  # No species provided
+                blocking=True,
+            )
+
+    async def test_get_plant_api_error(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test get plant handles API errors."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=MissingClientIdOrSecret("Invalid credentials")
+        )
+
+        with pytest.raises(MissingClientIdOrSecret):
+            await hass.services.async_call(
+                DOMAIN,
+                OPB_SERVICE_GET,
+                {"species": "monstera deliciosa"},
+                blocking=True,
+            )
+
+    async def test_get_plant_returns_empty_when_not_found(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test get plant returns empty dict when plant not found."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(return_value=None)
+
+        result = await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "unknown_plant"},
+            blocking=True,
+            return_response=True,
+        )
+
+        assert result == {}
+
+
+class TestUploadService:
+    """Tests for the upload service."""
+
+    async def test_upload_service_callable(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test upload service is callable."""
+        # The upload service should be callable even if there's nothing to upload
+        result = await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_UPLOAD,
+            {},
+            blocking=True,
+            return_response=True,
+        )
+
+        # Result should have a result key (even if the value is None)
+        assert "result" in result
+
+
+class TestCleanCacheServiceEdgeCases:
+    """Tests for clean cache service edge cases."""
+
+    async def test_clean_cache_with_default_hours(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test clean cache with default hours (no parameter)."""
+        # First get a plant to populate cache
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa"},
+            blocking=True,
+        )
+
+        # Clean cache without hours parameter (uses default)
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_CLEAN_CACHE,
+            {},
+            blocking=True,
+        )
+
+        # With default hours (24), recent cache entries should remain
+        assert "monstera deliciosa" in hass.data[DOMAIN][ATTR_SPECIES]
+
+    async def test_clean_cache_with_invalid_hours(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """Test clean cache with invalid hours parameter uses default."""
+        # First get a plant to populate cache
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa"},
+            blocking=True,
+        )
+
+        # Clean cache with invalid hours (string instead of int)
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_CLEAN_CACHE,
+            {"hours": "invalid"},
+            blocking=True,
+        )
+
+        # With invalid hours, uses default (24), recent entries should remain
+        assert "monstera deliciosa" in hass.data[DOMAIN][ATTR_SPECIES]


### PR DESCRIPTION
## Summary
- Add comprehensive config flow tests achieving 97% coverage for config_flow.py
- Add error handling tests for search and get plant services
- Add upload service test that uncovered a bug
- Add edge case tests for clean_cache service

## Bug Fix
Fixed `UnboundLocalError: cannot access local variable 'latest_data'` that occurred when the upload service was called with no plant devices configured. The variable was only defined inside the plant devices loop, causing a crash when accessed in the else branch.

## Coverage Improvement
| File | Before | After |
|------|--------|-------|
| `__init__.py` | 64% | 74% |
| `config_flow.py` | 32% | 97% |
| `uploader.py` | 34% | 48% |
| **Total** | **49%** | **70%** |

## New Tests
- `test_config_flow.py` - 9 new tests for config flow and options flow
- `test_init.py` - 8 new tests for error handling and edge cases

## Test plan
- [x] All 54 tests pass
- [x] ruff check passes
- [x] black formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)