### PR TITLE
Use explicit base_url for API and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .idea
+.junie/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Connects Home Assistant to the [OpenPlantbook API](https://open.plantbook.io/) f
   - [📦 Installation](#-installation)
   - [🔧 Setup](#-setup)
   - [⚙️ Configuration Options](#️-configuration-options)
+    - [📤 Upload Plant Sensor Data](#-upload-plant-sensor-data)
+    - [🌍 Share Location](#-share-location)
+    - [🌐 International Common Names](#-international-common-names)
+    - [🖼️ Automatically Download Images](#️-automatically-download-images)
   - [📡 Actions (Service Calls)](#-actions-service-calls)
   - [🖥️ GUI Example](#️-gui-example)
   - [☕ Support](#-support)
@@ -62,6 +66,7 @@ When enabled, the integration periodically (once a day) uploads sensor data from
 - First upload: last 24 hours of data
 - If sensors are disconnected, it retries daily for up to 7 days of historical data
 - Can also be triggered manually via the `openplantbook.upload` action
+- Daily uploads are scheduled at a randomized time-of-day per installation (stable for a given config entry) to even load distribution
 
 ### 🌍 Share Location
 
@@ -80,6 +85,12 @@ Location is configured in HA under **Settings** → **System** → **General**.
 > Enable DEBUG logging for the integration to see exactly what data is being shared.
 >
 > ![Debug logging](./images/debug-logging.png)
+
+### 🌐 International Common Names
+
+When enabled, the integration sends your Home Assistant language to OpenPlantbook so the API can return common names in that language when available.
+
+[More information about this OpenPlantbook feature](https://github.com/slaxor505/OpenPlantbook-client/wiki/Plant-Common-names).
 
 ### 🖼️ Automatically Download Images
 

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     OPB_MIN_DLI,
     OPB_MIN_LIGHT_MMOL,
     OPB_PID,
+    PLANTBOOK_BASEURL,
     OPB_SERVICE_CLEAN_CACHE,
     OPB_SERVICE_GET,
     OPB_SERVICE_SEARCH,
@@ -125,7 +126,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if ATTR_API not in hass.data[DOMAIN]:
         hass.data[DOMAIN][ATTR_API] = OpenPlantBookApi(
-            entry.data.get(CONF_CLIENT_ID), entry.data.get(CONF_CLIENT_SECRET)
+            entry.data.get(CONF_CLIENT_ID),
+            entry.data.get(CONF_CLIENT_SECRET),
+            base_url=PLANTBOOK_BASEURL,
         )
 
     if ATTR_SPECIES not in hass.data[DOMAIN]:

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -48,11 +48,11 @@ from .const import (
     OPB_MIN_DLI,
     OPB_MIN_LIGHT_MMOL,
     OPB_PID,
-    PLANTBOOK_BASEURL,
     OPB_SERVICE_CLEAN_CACHE,
     OPB_SERVICE_GET,
     OPB_SERVICE_SEARCH,
     OPB_SERVICE_UPLOAD,
+    PLANTBOOK_BASEURL,
 )
 from .plantbook_exception import OpenPlantbookException
 from .uploader import (

--- a/custom_components/openplantbook/config_flow.py
+++ b/custom_components/openplantbook/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     FLOW_UPLOAD_DATA,
     FLOW_UPLOAD_HASS_LOCATION_COORD,
     FLOW_UPLOAD_HASS_LOCATION_COUNTRY,
+    PLANTBOOK_BASEURL,
 )
 
 TITLE = "title"
@@ -52,7 +53,9 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> dict[str, str]
     # Check if values are not empty
     try:
         hass.data[DOMAIN][ATTR_API] = OpenPlantBookApi(
-            data[CONF_CLIENT_ID], data[CONF_CLIENT_SECRET]
+            data[CONF_CLIENT_ID],
+            data[CONF_CLIENT_SECRET],
+            base_url=PLANTBOOK_BASEURL,
         )
         await hass.data[DOMAIN][ATTR_API]._async_get_token()
         # TODO 4: Error messages for "unable to connect" and "creds are not valid" not working well.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ asyncio_default_fixture_loop_scope = function
 norecursedirs = .git
 filterwarnings =
     ignore::DeprecationWarning
+addopts = -p no:socket


### PR DESCRIPTION
## Summary
- Pass `base_url=PLANTBOOK_BASEURL` to `OpenPlantBookApi()` in both `__init__.py` and `config_flow.py`
- Document international common names feature in README
- Document randomized upload schedule in README
- Expand table of contents with new config option sections
- Add `.junie/` to `.gitignore`
- Add `-p no:socket` to `pytest.ini`

Split from #67.

## Test plan
- [ ] Verify integration connects to API correctly with explicit base_url
- [ ] Verify config flow validation still works with base_url parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)