### PR TITLE
feat: add cache bypass parameter to get service

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -144,6 +144,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "invalid service call, required attribute %s missing", ATTR_SPECIES
             )
 
+        # Allow callers to bypass the cache (e.g. plant integration "Force refresh")
+        use_cache = call.data.get("cache", True)
+        if not use_cache and species in hass.data[DOMAIN][ATTR_SPECIES]:
+            _LOGGER.debug(
+                "Cache bypass requested for %s, clearing cached data", species
+            )
+            del hass.data[DOMAIN][ATTR_SPECIES][species]
+
         # Here we try to ensure that we only run one API request for each species
         # The first process creates an empty dict, and accesses the API
         # Later requests for the same species either wait for the first one to complete

--- a/custom_components/openplantbook/services.yaml
+++ b/custom_components/openplantbook/services.yaml
@@ -21,6 +21,13 @@ get:
       required: true
       selector:
         text:
+    cache:
+      name: Use cache
+      description: Set to false to bypass the cache and fetch fresh data from the API
+      default: true
+      required: false
+      selector:
+        boolean:
 
 upload:
   name: Upload


### PR DESCRIPTION
## Summary
- Adds optional `cache` parameter (default: `true`) to the `openplantbook.get` service
- When `cache: false`, clears the cached data for the requested species before fetching fresh data from the API
- Fixes Olen/homeassistant-plant#392 — "Force refresh data from OpenPlantbook" was returning stale cached data (24-hour TTL) instead of re-fetching from the API

## Test plan
- [ ] Call `openplantbook.get` with `cache: false` — should fetch fresh data from API
- [ ] Call `openplantbook.get` without the parameter — should use cache as before
- [ ] Modify species data on openplantbook.io, then force refresh in plant integration — values should update

🤖 Generated with [Claude Code](https://claude.com/claude-code)