### PR TITLE
Release v1.5.0-beta1

### DIFF
--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -19,5 +19,5 @@
     "json-timeseries==0.1.7",
     "openplantbook-sdk==0.6.1"
   ],
-  "version": "1.4.0"
+  "version": "1.5.0-beta1"
 }


### PR DESCRIPTION
## Summary
- Bump version to 1.5.0-beta1
- Includes cache bypass parameter for the `get` service (#75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)