### PR TITLE
feat: add include/care support to the get service

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ data:
 > [!NOTE]
 > The species string must match exactly the `pid` returned by `openplantbook.search`.
 
+#### Extra data categories
+
+Request additional categories with the optional `include` parameter (comma-separated). Currently the API supports `care`, which adds `watering`, `sunlight`, `soil`, `pruning`, and `fertilization`:
+
+```yaml
+action: openplantbook.get
+data:
+  species: monstera deliciosa
+  include: care
+```
+
+The extra fields are merged into the same entity and returned in the service response. Cached entries remember which categories they already contain, so requesting `care` for a plant that was previously fetched without it triggers a fresh API call.
+
 Read results from `openplantbook.capsicum_annuum`:
 
 ```jinja2

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -161,22 +161,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # categories, e.g. "care"). An empty request is satisfied by any entry.
         requested_includes = _parse_includes(call.data.get(ATTR_INCLUDE))
 
-        # Allow callers to bypass the cache (e.g. plant integration "Force
-        # refresh"), and also force a refetch when a *completed* cached entry
-        # does not already contain all the requested include categories. We
-        # check OPB_PID so we never disturb the in-flight sentinel ({}) used by
-        # the concurrency guard below.
+        # Decide whether to drop a cached entry and refetch. We refetch when the
+        # caller bypasses the cache (cache: false) or when a cached entry does
+        # not already contain all the requested include categories. In both
+        # cases we require a *completed* entry (OPB_PID present), so we never
+        # delete the in-flight sentinel ({}) used by the concurrency guard
+        # below — a concurrent request waits for that fetch instead of starting
+        # a duplicate one.
         use_cache = call.data.get("cache", True)
         cached = hass.data[DOMAIN][ATTR_SPECIES].get(species)
-        includes_unsatisfied = (
+        includes_unsatisfied = not requested_includes.issubset(
+            set((cached or {}).get(OPB_ATTR_INCLUDES, []))
+        )
+        if (
             cached is not None
             and OPB_PID in cached
-            and not requested_includes.issubset(
-                set(cached.get(OPB_ATTR_INCLUDES, []))
-            )
-        )
-        if species in hass.data[DOMAIN][ATTR_SPECIES] and (
-            not use_cache or includes_unsatisfied
+            and (not use_cache or includes_unsatisfied)
         ):
             _LOGGER.debug(
                 "Refetching %s (bypass=%s, include=%s), clearing cached data",
@@ -294,7 +294,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # If more than one "get_plant" is triggered for the same species, we wait for up to
             # 10 seconds for the first process to complete the API request.
             # We don't want to return immediately, as we want the state object to be set by
-            # the running process before we return from this call
+            # the running process before we return from this call.
+            # Known limitation: if this request asked for extra `include`
+            # categories but the in-flight request did not, we return the
+            # in-flight (possibly base-only) result rather than refetching here.
+            # The next call for those categories will refetch, so this is a
+            # transient, self-correcting miss in the rare concurrent case.
             _LOGGER.debug(
                 "Another process is currently trying to get the data for %s",
                 species,

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     ATTR_API,
     ATTR_HOURS,
     ATTR_IMAGE,
+    ATTR_INCLUDE,
     ATTR_SPECIES,
     CACHE_TIME,
     DOMAIN,
@@ -38,6 +39,7 @@ from .const import (
     MMOL_LUX_RATIO_MAX,
     MMOL_LUX_RATIO_MIN,
     MMOL_TO_DLI_FACTOR,
+    OPB_ATTR_INCLUDES,
     OPB_ATTR_RESULTS,
     OPB_ATTR_SEARCH_RESULT,
     OPB_ATTR_TIMESTAMP,
@@ -111,6 +113,17 @@ def _enrich_plant_data_with_dli(plant_data: dict) -> None:
         plant_data[OPB_MAX_DLI] = round(float(max_mmol) * factor, 1)
     if min_mmol is not None:
         plant_data[OPB_MIN_DLI] = round(float(min_mmol) * factor, 1)
+
+
+def _parse_includes(include: str | None) -> set[str]:
+    """Parse the comma-separated `include` service parameter into a set.
+
+    Empty/whitespace-only input yields an empty set, which is a subset of any
+    cached entry's satisfied categories (so a plain `get` is always a cache hit).
+    """
+    if not include:
+        return set()
+    return {part.strip() for part in include.split(",") if part.strip()}
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -119,7 +119,9 @@ def _parse_includes(include: str | None) -> set[str]:
     """Parse the comma-separated `include` service parameter into a set.
 
     Empty/whitespace-only input yields an empty set, which is a subset of any
-    cached entry's satisfied categories (so a plain `get` is always a cache hit).
+    cached entry's satisfied categories — so a plain `get` never triggers an
+    include-driven refetch of an already-cached entry (a first fetch or normal
+    cache expiry still calls the API).
     """
     if not include:
         return set()

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -157,11 +157,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "invalid service call, required attribute %s missing", ATTR_SPECIES
             )
 
-        # Allow callers to bypass the cache (e.g. plant integration "Force refresh")
+        # Parse the optional `include` parameter (comma-separated extra data
+        # categories, e.g. "care"). An empty request is satisfied by any entry.
+        requested_includes = _parse_includes(call.data.get(ATTR_INCLUDE))
+
+        # Allow callers to bypass the cache (e.g. plant integration "Force
+        # refresh"), and also force a refetch when a *completed* cached entry
+        # does not already contain all the requested include categories. We
+        # check OPB_PID so we never disturb the in-flight sentinel ({}) used by
+        # the concurrency guard below.
         use_cache = call.data.get("cache", True)
-        if not use_cache and species in hass.data[DOMAIN][ATTR_SPECIES]:
+        cached = hass.data[DOMAIN][ATTR_SPECIES].get(species)
+        includes_unsatisfied = (
+            cached is not None
+            and OPB_PID in cached
+            and not requested_includes.issubset(
+                set(cached.get(OPB_ATTR_INCLUDES, []))
+            )
+        )
+        if species in hass.data[DOMAIN][ATTR_SPECIES] and (
+            not use_cache or includes_unsatisfied
+        ):
             _LOGGER.debug(
-                "Cache bypass requested for %s, clearing cached data", species
+                "Refetching %s (bypass=%s, include=%s), clearing cached data",
+                species,
+                not use_cache,
+                sorted(requested_includes),
             )
             del hass.data[DOMAIN][ATTR_SPECIES][species]
 
@@ -169,10 +190,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # The first process creates an empty dict, and accesses the API
         # Later requests for the same species either wait for the first one to complete
         # or they return immediately if we already have the data we need
-        _LOGGER.debug("get_plant %s", species)
+        _LOGGER.debug("get_plant %s (include=%s)", species, sorted(requested_includes))
         if species not in hass.data[DOMAIN][ATTR_SPECIES]:
             _LOGGER.debug("I am the first process to get %s", species)
             hass.data[DOMAIN][ATTR_SPECIES][species] = {}
+            # Pass requested extra categories straight through to the API. The
+            # SDK merges `lang` in and treats an empty dict as no extra params.
+            extra_params = {}
+            if requested_includes:
+                extra_params["include"] = ",".join(sorted(requested_includes))
             try:
                 # Optionally pass Home Assistant language to OpenPlantbook API
                 send_lang = entry.options.get(FLOW_SEND_LANG, True)
@@ -184,11 +210,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         lang_code = "en"
                     plant_data = await hass.data[DOMAIN][
                         ATTR_API
-                    ].async_plant_detail_get(species, lang=lang_code)
+                    ].async_plant_detail_get(
+                        species, lang=lang_code, params=extra_params
+                    )
                 else:
                     plant_data = await hass.data[DOMAIN][
                         ATTR_API
-                    ].async_plant_detail_get(species)
+                    ].async_plant_detail_get(species, params=extra_params)
             except RateLimitError as err:
                 plant_data = None
                 _LOGGER.warning(
@@ -218,6 +246,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.debug("Got data for %s", species)
                 _enrich_plant_data_with_dli(plant_data)
                 plant_data[OPB_ATTR_TIMESTAMP] = datetime.now().isoformat()
+                plant_data[OPB_ATTR_INCLUDES] = sorted(requested_includes)
                 hass.data[DOMAIN][ATTR_SPECIES][species] = plant_data
                 entity_id = async_generate_entity_id(
                     f"{DOMAIN}.{{}}", plant_data[OPB_PID], current_ids={}

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -7,6 +7,7 @@ ATTR_PLANT_INSTANCE = "plant_instance"
 ATTR_SPECIES = "species"
 ATTR_API = "api"
 ATTR_HOURS = "hours"
+ATTR_INCLUDE = "include"
 ATTR_IMAGE = "image_url"
 CACHE_TIME = 24
 
@@ -15,6 +16,9 @@ OPB_ATTR_SEARCH_RESULT = "search_result"
 OPB_ATTR_RESULT = "result"
 OPB_ATTR_RESULTS = "results"
 OPB_ATTR_TIMESTAMP = "timestamp"
+# Internal marker on a cached plant_data dict recording which extra
+# `include` categories that entry already satisfies (e.g. ["care"]).
+OPB_ATTR_INCLUDES = "_fetched_includes"
 
 OPB_SERVICE_SEARCH = "search"
 OPB_SERVICE_GET = "get"

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -16,8 +16,8 @@ OPB_ATTR_SEARCH_RESULT = "search_result"
 OPB_ATTR_RESULT = "result"
 OPB_ATTR_RESULTS = "results"
 OPB_ATTR_TIMESTAMP = "timestamp"
-# Internal marker on a cached plant_data dict recording which extra
-# `include` categories that entry already satisfies (e.g. ["care"]).
+# Internal marker stored on a cached plant_data dict: the list of extra
+# `include` categories that the cached entry already satisfies (e.g. ["care"]).
 OPB_ATTR_INCLUDES = "_fetched_includes"
 
 OPB_SERVICE_SEARCH = "search"

--- a/custom_components/openplantbook/services.yaml
+++ b/custom_components/openplantbook/services.yaml
@@ -21,6 +21,13 @@ get:
       required: true
       selector:
         text:
+    include:
+      name: Include extra data
+      description: Comma-separated list of extra data categories to include (currently only 'care'). Leave empty for standard data.
+      example: care
+      required: false
+      selector:
+        text:
     cache:
       name: Use cache
       description: Set to false to bypass the cache and fetch fresh data from the API

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -319,6 +319,31 @@ class TestGetPlantServiceErrors:
         assert result == {}
 
 
+class TestParseIncludes:
+    """Tests for the _parse_includes helper."""
+
+    def test_none_returns_empty_set(self) -> None:
+        from custom_components.openplantbook import _parse_includes
+
+        assert _parse_includes(None) == set()
+
+    def test_empty_string_returns_empty_set(self) -> None:
+        from custom_components.openplantbook import _parse_includes
+
+        assert _parse_includes("") == set()
+        assert _parse_includes("   ") == set()
+
+    def test_single_category(self) -> None:
+        from custom_components.openplantbook import _parse_includes
+
+        assert _parse_includes("care") == {"care"}
+
+    def test_comma_separated_with_whitespace(self) -> None:
+        from custom_components.openplantbook import _parse_includes
+
+        assert _parse_includes("care, poison ,care") == {"care", "poison"}
+
+
 class TestUploadService:
     """Tests for the upload service."""
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,6 +25,37 @@ from custom_components.openplantbook.const import (
 from custom_components.openplantbook.plantbook_exception import OpenPlantbookException
 
 
+def _make_detail_side_effect():
+    """Build an async_plant_detail_get side_effect that adds care fields
+    only when params requests include=care (mirrors the real API)."""
+
+    async def _side_effect(species, lang=None, params=None, **kwargs):
+        data = {
+            "pid": "monstera deliciosa",
+            "display_pid": "Monstera deliciosa",
+            "alias": "Swiss cheese plant",
+            "image_url": "https://example.com/monstera.jpg",
+            "min_temp": 15,
+            "max_temp": 30,
+            "min_soil_moist": 20,
+            "max_soil_moist": 60,
+        }
+        include = (params or {}).get("include", "")
+        if "care" in include:
+            data.update(
+                {
+                    "watering": "Likes wet envs; reduce watering in winter.",
+                    "sunlight": "Relatively shade-tolerant, prefers half-shade.",
+                    "soil": "Peat mixed with coarse sand or hydroponics",
+                    "pruning": "Timely remove dead and yellowish leaves.",
+                    "fertilization": "Dilute fertilizer once every 15 days.",
+                }
+            )
+        return data
+
+    return _side_effect
+
+
 class TestIntegrationSetup:
     """Tests for integration setup."""
 
@@ -649,3 +680,134 @@ class TestGetServiceInclude:
 
         call = mock_openplantbook_api.async_plant_detail_get.call_args
         assert call.kwargs["params"] == {}
+
+
+class TestGetServiceIncludeCaching:
+    """Tests for include-aware caching and merge behaviour."""
+
+    async def test_base_then_care_refetches(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """A base fetch followed by include=care must hit the API again."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=_make_detail_side_effect()
+        )
+
+        await hass.services.async_call(
+            DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+        )
+        result = await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+            return_response=True,
+        )
+
+        assert mock_openplantbook_api.async_plant_detail_get.call_count == 2
+        assert result.get("watering") == "Likes wet envs; reduce watering in winter."
+
+    async def test_care_then_care_served_from_cache(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """A second identical include=care request is served from cache."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=_make_detail_side_effect()
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+
+        assert mock_openplantbook_api.async_plant_detail_get.call_count == 1
+
+    async def test_base_after_care_uses_cache_and_keeps_care(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """A base get after a fresh care fetch is a cache hit and still has care."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=_make_detail_side_effect()
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+        result = await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa"},
+            blocking=True,
+            return_response=True,
+        )
+
+        assert mock_openplantbook_api.async_plant_detail_get.call_count == 1
+        assert result.get("soil") == "Peat mixed with coarse sand or hydroponics"
+
+    async def test_care_fields_published_as_entity_attributes(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """care fields are merged into the HA entity attributes."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=_make_detail_side_effect()
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+
+        state = hass.states.get("openplantbook.monstera_deliciosa")
+        assert state is not None
+        assert state.attributes.get("watering") is not None
+
+    async def test_cache_bypass_with_include(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """cache=false forces a refetch even for an already-satisfied include."""
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            side_effect=_make_detail_side_effect()
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care", "cache": False},
+            blocking=True,
+        )
+
+        assert mock_openplantbook_api.async_plant_detail_get.call_count == 2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -611,3 +611,41 @@ class TestImageDownload:
         assert result is not None
         # Image URL should remain the original HTTP URL
         assert result.get(ATTR_IMAGE, "").startswith("https://")
+
+
+class TestGetServiceInclude:
+    """Tests for the include parameter on the get service."""
+
+    async def test_include_param_passed_to_api(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """include=care must reach the SDK as a params query argument."""
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa", "include": "care"},
+            blocking=True,
+        )
+
+        call = mock_openplantbook_api.async_plant_detail_get.call_args
+        assert call.kwargs["params"] == {"include": "care"}
+
+    async def test_no_include_passes_empty_params(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+    ) -> None:
+        """A plain get passes an empty params dict (no extra query args)."""
+        await hass.services.async_call(
+            DOMAIN,
+            OPB_SERVICE_GET,
+            {"species": "monstera deliciosa"},
+            blocking=True,
+        )
+
+        call = mock_openplantbook_api.async_plant_detail_get.call_args
+        assert call.kwargs["params"] == {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,7 +41,8 @@ def _make_detail_side_effect():
             "max_soil_moist": 60,
         }
         include = (params or {}).get("include", "")
-        if "care" in include:
+        categories = {c.strip() for c in include.split(",") if c.strip()}
+        if "care" in categories:
             data.update(
                 {
                     "watering": "Likes wet envs; reduce watering in winter.",


### PR DESCRIPTION
## Summary

Adds an optional `include` parameter to the `openplantbook.get` service so callers can request extra data categories from the OpenPlantbook API. Currently the API supports `care`, which adds five fields: `watering`, `sunlight`, `soil`, `pruning`, and `fertilization`.

**Design ("merge"):** the cache stays keyed by `species` and there remains one HA entity per PID. Each cached entry records which include-categories it already satisfies (internal `_fetched_includes` key), so a request for `care` against an entry that only holds base data triggers a refetch+replace, while a plain `get` (or a repeat `care` request) is served from cache. `clean_cache` is intentionally unchanged — the cache key and entity identity don't change.

This was chosen over a `(species, include)` tuple-keyed cache (as used in the slaxor505 fork) because the real `care` payload is small and flat (~340 bytes, 5 strings), so there's no need for the extra cache/entity complexity. No SDK bump is needed: `openplantbook-sdk==0.6.1` already passes `params` straight through as query args.

### Changes
- `const.py`: add `ATTR_INCLUDE` and `OPB_ATTR_INCLUDES`.
- `__init__.py`: `_parse_includes` helper; make `get_plant` include-aware (refetch when a completed cached entry lacks the requested categories, guarded so the in-flight sentinel is never disturbed); pass `params={"include": ...}` to the SDK; record satisfied categories on store.
- `services.yaml`: expose the `include` field on the `get` service.
- `README.md`: document `include=care`.
- Tests: param pass-through + 5 caching/merge/bypass behaviour tests.

### Backwards compatibility
A plain `get` with no `include` behaves exactly as before (empty include set is a subset of any cached entry → always a cache hit), and the existing `cache` bypass param is unaffected.

### Known benign edge case
With `cache: false`, a plain `get` refetches base-only data and drops previously-fetched `care` until the next `care` request. With the default `cache: true`, care is preserved across subsequent base gets.

## Test Plan
- [x] `uv run pytest tests/` → 83 passed
- [x] `uv run ruff check custom_components tests` → clean
- [x] Verified against the live OpenPlantbook API that `include=care` returns the five documented fields

## Follow-ups (not in this PR)
- Version bump in `manifest.json` (currently 1.4.0) is intentionally deferred to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)