### PR TITLE
fix: ignore query string when deriving downloaded image filename

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -212,8 +212,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if entry.options.get(FLOW_DOWNLOAD_IMAGES) and plant_data.get(
                     ATTR_IMAGE
                 ):
+                    # Derive the filename from the URL path only, ignoring any
+                    # cache-busting query string (e.g. ...jpg?v=abc123) so the
+                    # saved filename stays stable across refreshes.
                     filename = slugify(
-                        urllib.parse.unquote(os.path.basename(plant_data[ATTR_IMAGE])),
+                        urllib.parse.unquote(
+                            os.path.basename(
+                                urllib.parse.urlparse(plant_data[ATTR_IMAGE]).path
+                            )
+                        ),
                         separator=" ",
                     ).replace(" jpg", ".jpg")
                     raise_if_invalid_filename(filename)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -473,6 +473,67 @@ class TestImageDownload:
         assert downloaded_file.exists()
         assert downloaded_file.read_bytes() == b"fake image data"
 
+    async def test_get_plant_image_filename_ignores_query_string(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry_with_download: MockConfigEntry,
+        mock_openplantbook_api: MagicMock,
+        tmp_path,
+    ) -> None:
+        """A cache-busting query string in the image URL must not leak into the filename."""
+        download_dir = tmp_path / "www" / "images" / "plants"
+        download_dir.mkdir(parents=True)
+
+        mock_config_entry_with_download.add_to_hass(hass)
+        hass.config_entries.async_update_entry(
+            mock_config_entry_with_download,
+            options={
+                **mock_config_entry_with_download.options,
+                FLOW_DOWNLOAD_PATH: str(download_dir),
+            },
+        )
+
+        # OpenPlantbook serves cache-busted image URLs, e.g. ...jpg?v=abc123
+        mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+            return_value={
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "image_url": "https://example.com/monstera.jpg?v=abc123",
+            }
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=b"fake image data")
+        mock_session = MagicMock()
+        mock_session.get = AsyncMock(return_value=mock_resp)
+
+        with patch(
+            "custom_components.openplantbook.async_get_clientsession",
+            return_value=mock_session,
+        ):
+            await hass.config_entries.async_setup(
+                mock_config_entry_with_download.entry_id
+            )
+            await hass.async_block_till_done()
+            hass.data[DOMAIN][ATTR_SPECIES].clear()
+
+            result = await hass.services.async_call(
+                DOMAIN,
+                OPB_SERVICE_GET,
+                {"species": "monstera deliciosa"},
+                blocking=True,
+                return_response=True,
+            )
+
+        # Filename is derived from the URL path only — query string is stripped.
+        assert (download_dir / "monstera.jpg").exists()
+        # No stray file carrying the query string was created.
+        saved = [p.name for p in download_dir.iterdir()]
+        assert saved == ["monstera.jpg"], saved
+        assert "?" not in result.get(ATTR_IMAGE, "")
+        assert "abc123" not in result.get(ATTR_IMAGE, "")
+
     async def test_get_plant_skips_existing_image(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary

OpenPlantbook now serves **cache-busted image URLs** (e.g. `https://opb-img.plantbook.io/monstera%20deliciosa.jpg?v=abc123`). Our image-download code derived the filename with `os.path.basename(url)`, which keeps the query string — so the saved file became `monstera.jpg v abc123` (after slugify), a *new* file on every refresh instead of reusing the cached image.

This derives the filename from the URL **path only** via `urllib.parse.urlparse(url).path`, so the query string is stripped and the filename stays stable.

```python
# before
os.path.basename(plant_data[ATTR_IMAGE])
# after
os.path.basename(urllib.parse.urlparse(plant_data[ATTR_IMAGE]).path)
```

This mirrors a fix in the `slaxor505` fork (v1.5).

> Note: the related "handle `PermissionError` when writing the image" hardening from that fork is already present in our `async_download_image`, so it is intentionally **not** part of this PR.

## Test Plan
- [x] New regression test `test_get_plant_image_filename_ignores_query_string` — feeds an `image_url` containing `?v=abc123`, asserts the only saved file is `monstera.jpg` and the rewritten `/local/` URL contains no query string. Verified it **fails** before the fix and **passes** after.
- [x] `uv run pytest tests/` → 73 passed
- [x] `uv run ruff check custom_components tests` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)