### PR TITLE
chore: release 1.5.0-beta2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 .pyre/
 .idea
 .junie/
+
+# uv lock file (environment is managed via uv; not tracked for this integration)
+uv.lock
+
+# Local planning / agent artifacts
+/docs/superpowers/

--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -19,5 +19,5 @@
     "json-timeseries==0.1.7",
     "openplantbook-sdk==0.6.1"
   ],
-  "version": "1.5.0-beta1"
+  "version": "1.5.0-beta2"
 }


### PR DESCRIPTION
Prepares the **1.5.0-beta2** pre-release.

## Changes in this PR
- Bump `manifest.json` version `1.5.0-beta1` → `1.5.0-beta2` (the existing `v1.5.0-beta1` pre-release is already published, so the version string must advance).
- Gitignore `uv.lock` and local planning artifacts (`/docs/superpowers/`).

## What 1.5.0-beta2 adds over 1.5.0-beta1
- **`include` / `care`** — the `openplantbook.get` service gains an optional `include` parameter to request extra data categories (currently `care`: `watering`, `sunlight`, `soil`, `pruning`, `fertilization`), with include-aware caching. (#78)
- **Image filename cache-busting fix** — downloaded image filenames are now derived from the URL path only, ignoring `?v=...` query strings, so files stay stable across refreshes. (#79)

## Versioning note
Minor bump on the 1.5.0 line per SemVer (new backwards-compatible feature), independent of the `slaxor505` fork's numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)