### PR TITLE
chore: release 1.5.0 (stable) + care docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ data:
 
 The extra fields are merged into the same entity and returned in the service response. Cached entries remember which categories they already contain, so requesting `care` for a plant that was previously fetched without it triggers a fresh API call.
 
+After an `include: care` call, the care fields are available as attributes on the entity:
+
+```jinja2
+* Watering: {{ state_attr('openplantbook.monstera_deliciosa', 'watering') }}
+* Sunlight: {{ state_attr('openplantbook.monstera_deliciosa', 'sunlight') }}
+* Soil: {{ state_attr('openplantbook.monstera_deliciosa', 'soil') }}
+* Pruning: {{ state_attr('openplantbook.monstera_deliciosa', 'pruning') }}
+* Fertilization: {{ state_attr('openplantbook.monstera_deliciosa', 'fertilization') }}
+```
+
 Read results from `openplantbook.capsicum_annuum`:
 
 ```jinja2

--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -19,5 +19,5 @@
     "json-timeseries==0.1.7",
     "openplantbook-sdk==0.6.1"
   ],
-  "version": "1.5.0-beta2"
+  "version": "1.5.0"
 }

--- a/examples/GUI.md
+++ b/examples/GUI.md
@@ -92,7 +92,9 @@ actions:
 
 ### 🌱 Fetch Details on Selection
 
-Gets full plant data when a species is selected from the dropdown:
+Gets full plant data when a species is selected from the dropdown. The
+optional `include: care` also fetches the care guidance (watering, sunlight,
+soil, pruning, fertilization):
 
 ```yaml
 alias: Get Info From Openplantbook
@@ -103,6 +105,7 @@ actions:
   - action: openplantbook.get
     data:
       species: "{{ states('input_select.openplantbook_searchresults') }}"
+      include: care
 ```
 
 ### 🗑️ Clear Cache on Button Press
@@ -138,7 +141,7 @@ entities:
 
 ### Plant Info Card
 
-A Markdown card that shows the selected plant's image, species, and thresholds:
+A Markdown card that shows the selected plant's image, species, thresholds, and (when fetched with `include: care`) care guidance:
 
 ```yaml
 type: markdown
@@ -166,5 +169,15 @@ content: |
   | Humidity             | {{ state_attr(plant, 'min_env_humid') }}  |    | {{ state_attr(plant, 'max_env_humid') }}  | %     |
   | Illumination         | {{ state_attr(plant, 'min_light_lux') }}  |    | {{ state_attr(plant, 'max_light_lux') }}  | lx    |
   | Daily Light Integral | {{ min_dli }}                             |    | {{ max_dli }}                             | mol/d⋅m² |
+
+  {% if state_attr(plant, 'watering') %}
+  ## Care
+
+  - **Watering:** {{ state_attr(plant, 'watering') }}
+  - **Sunlight:** {{ state_attr(plant, 'sunlight') }}
+  - **Soil:** {{ state_attr(plant, 'soil') }}
+  - **Pruning:** {{ state_attr(plant, 'pruning') }}
+  - **Fertilization:** {{ state_attr(plant, 'fertilization') }}
+  {% endif %}
   {% endif %}
 ```


### PR DESCRIPTION
Promotes the 1.5.0 line to **stable** after `1.5.0-beta2` tested cleanly (incl. the `include`/`care` feature), and rounds out the docs/examples for it.

## Changes
- **Version:** `manifest.json` `1.5.0-beta2` → `1.5.0`. Merging this triggers the Auto Release workflow to publish **v1.5.0** as a normal (non-prerelease) release.
- **README:** added an example reading the care fields (`watering`, `sunlight`, `soil`, `pruning`, `fertilization`) as entity attributes after an `include: care` call.
- **examples/GUI.md:** the get automation now fetches with `include: care`, and the Plant Info card gained a guarded **Care** section that renders those fields when present.

## The 1.5.0 line since 1.4.0
- `include` / `care` on `openplantbook.get` (#78)
- Image filename cache-busting fix (#79)
- `cache` bypass parameter on `get` (shipped in 1.5.0-beta1)

## Notes
- No code changes here — docs + version only. Full suite green (84 passed).
- Versioned per SemVer of our own changes; independent of the slaxor505 fork's numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)