### PR TITLE
Real entities with unique_ids (#83)

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -419,6 +419,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ent_reg = er.async_get(hass)
             for species in list(hass.data[DOMAIN][ATTR_SPECIES]):
                 value = hass.data[DOMAIN][ATTR_SPECIES][species]
+                # Skip in-flight entries: the get_plant concurrency guard stores
+                # an empty sentinel dict ({}) before the API call completes, so it
+                # has no timestamp/pid yet. It will be cleaned on a later pass.
+                if OPB_ATTR_TIMESTAMP not in value:
+                    continue
                 if datetime.now() > datetime.fromisoformat(
                     value[OPB_ATTR_TIMESTAMP]
                 ) + timedelta(hours=hours):
@@ -479,6 +484,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Setup optionFlow updates listener
     entry.async_on_unload(entry.add_update_listener(config_update_listener))
 
+    # Create the search-result entity BEFORE registering the services, so a
+    # `search` call that arrives as soon as the service appears always finds the
+    # stored entity (avoids a KeyError during the setup window).
+    search_entity = OpenPlantbookSearchResult(entry)
+    await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities([search_entity])
+    hass.data[DOMAIN][DATA_SEARCH_ENTITY] = search_entity
+
     hass.services.async_register(
         DOMAIN, OPB_SERVICE_SEARCH, search_plantbook, None, SupportsResponse.OPTIONAL
     )
@@ -495,9 +507,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         None,
         SupportsResponse.OPTIONAL,
     )
-    search_entity = OpenPlantbookSearchResult(entry)
-    await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities([search_entity])
-    hass.data[DOMAIN][DATA_SEARCH_ENTITY] = search_entity
 
     return True
 

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -305,8 +305,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         )
 
                 _LOGGER.debug("data stored for %s: %s", species, plant_data)
+                # Key the entity holder by the canonical pid (not the raw
+                # service input), so different inputs that resolve to the same
+                # pid (casing/alias differences) map to the one entity instead
+                # of colliding on the shared entity_id/unique_id.
+                pid = plant_data[OPB_PID]
                 species_entities = hass.data[DOMAIN][DATA_SPECIES_ENTITIES]
-                existing_entity = species_entities.get(species)
+                existing_entity = species_entities.get(pid)
                 if existing_entity is None:
                     species_entity = OpenPlantbookSpecies(entry, entity_id, plant_data)
                     await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities(
@@ -315,7 +320,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     # Record the entity only after it is successfully added, so a
                     # failed add does not leave a phantom (unattached) entity that
                     # a later update would call async_write_ha_state() on.
-                    species_entities[species] = species_entity
+                    species_entities[pid] = species_entity
                 else:
                     existing_entity.async_update_data(plant_data)
                 return plant_data
@@ -418,7 +423,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     value[OPB_ATTR_TIMESTAMP]
                 ) + timedelta(hours=hours):
                     _LOGGER.debug("Removing %s from cache", species)
-                    entity = hass.data[DOMAIN][DATA_SPECIES_ENTITIES].pop(species, None)
+                    entity = hass.data[DOMAIN][DATA_SPECIES_ENTITIES].pop(
+                        value[OPB_PID], None
+                    )
                     if entity is not None:
                         entity_id = entity.entity_id
                         await entity.async_remove()
@@ -514,6 +521,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_remove(DOMAIN, OPB_SERVICE_SEARCH)
     hass.services.async_remove(DOMAIN, OPB_SERVICE_GET)
     hass.services.async_remove(DOMAIN, OPB_SERVICE_CLEAN_CACHE)
+    hass.services.async_remove(DOMAIN, OPB_SERVICE_UPLOAD)
     # Clear per-entry data but keep the EntityComponent, which is reused across
     # reloads (it owns the openplantbook.* entity platform).
     component = hass.data[DOMAIN].get(DATA_COMPONENT)

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -149,6 +149,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if ATTR_SPECIES not in hass.data[DOMAIN]:
         hass.data[DOMAIN][ATTR_SPECIES] = {}
 
+    # Backfill a unique_id for entries created before this was set in the
+    # config flow, so existing installs also gain one (silences the repair
+    # warning for the entry). Done before the update listener is registered so
+    # it does not trigger an options-reload.
+    if entry.unique_id is None and (client_id := entry.data.get(CONF_CLIENT_ID)):
+        hass.config_entries.async_update_entry(entry, unique_id=client_id)
+
     async def get_plant(call: ServiceCall) -> ServiceResponse:
         if DOMAIN not in hass.data:
             _LOGGER.error("no data found for domain %s", DOMAIN)

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -428,9 +428,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     value[OPB_ATTR_TIMESTAMP]
                 ) + timedelta(hours=hours):
                     _LOGGER.debug("Removing %s from cache", species)
-                    entity = hass.data[DOMAIN][DATA_SPECIES_ENTITIES].pop(
-                        value[OPB_PID], None
-                    )
+                    pid = value[OPB_PID]
+                    hass.data[DOMAIN][ATTR_SPECIES].pop(species)
+                    # The same pid can be cached under several input keys
+                    # (casing/alias differences map to one canonical pid, hence
+                    # one shared entity). Only tear the entity down once the last
+                    # cache entry referencing this pid is gone, so an expiring
+                    # key doesn't strand a still-cached one without its state.
+                    if any(
+                        v.get(OPB_PID) == pid
+                        for v in hass.data[DOMAIN][ATTR_SPECIES].values()
+                    ):
+                        continue
+                    entity = hass.data[DOMAIN][DATA_SPECIES_ENTITIES].pop(pid, None)
                     if entity is not None:
                         entity_id = entity.entity_id
                         await entity.async_remove()
@@ -439,7 +449,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         # entities.
                         if ent_reg.async_get(entity_id) is not None:
                             ent_reg.async_remove(entity_id)
-                    hass.data[DOMAIN][ATTR_SPECIES].pop(species)
 
     def _write_file(path: str, data: bytes) -> None:
         """Write binary data to a file (runs in executor)."""

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
@@ -59,12 +60,7 @@ from .const import (
     OPB_SERVICE_UPLOAD,
     PLANTBOOK_BASEURL,
 )
-from .entity import (
-    OpenPlantbookSearchResult,
-)
-from .entity import (
-    OpenPlantbookSpecies as OpenPlantbookSpecies,  # re-exported; wired up in next task
-)
+from .entity import OpenPlantbookSearchResult, OpenPlantbookSpecies
 from .plantbook_exception import OpenPlantbookException
 from .uploader import (
     async_setup_upload_schedule,
@@ -309,9 +305,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         )
 
                 _LOGGER.debug("data stored for %s: %s", species, plant_data)
-                hass.states.async_set(
-                    entity_id, plant_data[OPB_DISPLAY_PID], plant_data
-                )
+                species_entities = hass.data[DOMAIN][DATA_SPECIES_ENTITIES]
+                existing_entity = species_entities.get(species)
+                if existing_entity is None:
+                    species_entity = OpenPlantbookSpecies(entry, entity_id, plant_data)
+                    await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities(
+                        [species_entity]
+                    )
+                    # Record the entity only after it is successfully added, so a
+                    # failed add does not leave a phantom (unattached) entity that
+                    # a later update would call async_write_ha_state() on.
+                    species_entities[species] = species_entity
+                else:
+                    existing_entity.async_update_data(plant_data)
                 return plant_data
             del hass.data[DOMAIN][ATTR_SPECIES][species]
             return {}
@@ -405,16 +411,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if hours is None or not isinstance(hours, int):
             hours = CACHE_TIME
         if ATTR_SPECIES in hass.data[DOMAIN]:
+            ent_reg = er.async_get(hass)
             for species in list(hass.data[DOMAIN][ATTR_SPECIES]):
                 value = hass.data[DOMAIN][ATTR_SPECIES][species]
                 if datetime.now() > datetime.fromisoformat(
                     value[OPB_ATTR_TIMESTAMP]
                 ) + timedelta(hours=hours):
                     _LOGGER.debug("Removing %s from cache", species)
-                    entity_id = async_generate_entity_id(
-                        f"{DOMAIN}.{{}}", value[OPB_PID], current_ids={}
-                    )
-                    hass.states.async_remove(entity_id)
+                    entity = hass.data[DOMAIN][DATA_SPECIES_ENTITIES].pop(species, None)
+                    if entity is not None:
+                        entity_id = entity.entity_id
+                        await entity.async_remove()
+                        # Purge the registry entry too, so dynamically-removed
+                        # species do not accumulate as stale "unavailable"
+                        # entities.
+                        if ent_reg.async_get(entity_id) is not None:
+                            ent_reg.async_remove(entity_id)
                     hass.data[DOMAIN][ATTR_SPECIES].pop(species)
 
     def _write_file(path: str, data: bytes) -> None:

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -500,6 +500,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities([search_entity])
     hass.data[DOMAIN][DATA_SEARCH_ENTITY] = search_entity
 
+    # The per-species cache is in-memory only, so on a fresh start (e.g. after a
+    # restart) it is empty and clean_cache has nothing to expire. Purge any
+    # per-species entities left in the registry by a previous run so they don't
+    # linger as stale, unavailable entities. The persistent search_result entity
+    # is kept; no per-species entities are live yet at this point in setup.
+    ent_reg = er.async_get(hass)
+    for reg_entry in list(ent_reg.entities.values()):
+        if (
+            reg_entry.platform == DOMAIN
+            and reg_entry.domain == DOMAIN
+            and reg_entry.entity_id != search_entity.entity_id
+        ):
+            ent_reg.async_remove(reg_entry.entity_id)
+
     hass.services.async_register(
         DOMAIN, OPB_SERVICE_SEARCH, search_plantbook, None, SupportsResponse.OPTIONAL
     )

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.util import raise_if_invalid_filename, slugify
 from openplantbook_sdk import MissingClientIdOrSecret, OpenPlantBookApi
 from openplantbook_sdk.sdk import RateLimitError
@@ -32,6 +33,9 @@ from .const import (
     ATTR_INCLUDE,
     ATTR_SPECIES,
     CACHE_TIME,
+    DATA_COMPONENT,
+    DATA_SEARCH_ENTITY,
+    DATA_SPECIES_ENTITIES,
     DOMAIN,
     FLOW_DOWNLOAD_IMAGES,
     FLOW_DOWNLOAD_PATH,
@@ -41,7 +45,6 @@ from .const import (
     MMOL_TO_DLI_FACTOR,
     OPB_ATTR_INCLUDES,
     OPB_ATTR_RESULTS,
-    OPB_ATTR_SEARCH_RESULT,
     OPB_ATTR_TIMESTAMP,
     OPB_DISPLAY_PID,
     OPB_MAX_DLI,
@@ -55,6 +58,12 @@ from .const import (
     OPB_SERVICE_SEARCH,
     OPB_SERVICE_UPLOAD,
     PLANTBOOK_BASEURL,
+)
+from .entity import (
+    OpenPlantbookSearchResult,
+)
+from .entity import (
+    OpenPlantbookSpecies as OpenPlantbookSpecies,  # re-exported; wired up in next task
 )
 from .plantbook_exception import OpenPlantbookException
 from .uploader import (
@@ -155,6 +164,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # it does not trigger an options-reload.
     if entry.unique_id is None and (client_id := entry.data.get(CONF_CLIENT_ID)):
         hass.config_entries.async_update_entry(entry, unique_id=client_id)
+
+    if DATA_COMPONENT not in hass.data[DOMAIN]:
+        # One EntityComponent owns all openplantbook.* entities for the life of
+        # this HA instance; it is reused across config-entry reloads.
+        hass.data[DOMAIN][DATA_COMPONENT] = EntityComponent(_LOGGER, DOMAIN, hass)
+    if DATA_SPECIES_ENTITIES not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][DATA_SPECIES_ENTITIES] = {}
 
     async def get_plant(call: ServiceCall) -> ServiceResponse:
         if DOMAIN not in hass.data:
@@ -371,7 +387,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for plant in plant_data[OPB_ATTR_RESULTS]:
             pid = plant[OPB_PID]
             attrs[pid] = plant[OPB_DISPLAY_PID]
-        hass.states.async_set(f"{DOMAIN}.{OPB_ATTR_SEARCH_RESULT}", state, attrs)
+        hass.data[DOMAIN][DATA_SEARCH_ENTITY].async_update_results(state, attrs)
 
         return attrs
 
@@ -460,7 +476,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         None,
         SupportsResponse.OPTIONAL,
     )
-    hass.states.async_set(f"{DOMAIN}.{OPB_ATTR_SEARCH_RESULT}", 0)
+    search_entity = OpenPlantbookSearchResult(entry)
+    await hass.data[DOMAIN][DATA_COMPONENT].async_add_entities([search_entity])
+    hass.data[DOMAIN][DATA_SEARCH_ENTITY] = search_entity
 
     return True
 
@@ -477,13 +495,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # limit=30,
     )
     _LOGGER.debug("Removing search result")
-    hass.states.async_remove(f"{DOMAIN}.{OPB_ATTR_SEARCH_RESULT}")
+    search_entity = hass.data[DOMAIN].get(DATA_SEARCH_ENTITY)
+    if search_entity is not None:
+        await search_entity.async_remove()
     _LOGGER.debug("Removing services")
     hass.services.async_remove(DOMAIN, OPB_SERVICE_SEARCH)
     hass.services.async_remove(DOMAIN, OPB_SERVICE_GET)
     hass.services.async_remove(DOMAIN, OPB_SERVICE_CLEAN_CACHE)
-    # And we get rid of the rest
-    hass.data.pop(DOMAIN)
+    # Clear per-entry data but keep the EntityComponent, which is reused across
+    # reloads (it owns the openplantbook.* entity platform).
+    component = hass.data[DOMAIN].get(DATA_COMPONENT)
+    hass.data[DOMAIN] = {DATA_COMPONENT: component} if component else {}
 
     return True
 

--- a/custom_components/openplantbook/config_flow.py
+++ b/custom_components/openplantbook/config_flow.py
@@ -101,10 +101,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
 
             if not errors:
-                # Single-account integration: key the entry on the client_id so
-                # a duplicate setup aborts instead of creating a second entry.
+                # Persist the client_id as the entry's unique_id (stable per
+                # account; also used as the entities' unique_id prefix).
+                # Single-instance is enforced by manifest `single_config_entry`,
+                # which blocks a second entry regardless of client_id.
                 await self.async_set_unique_id(user_input[CONF_CLIENT_ID])
-                self._abort_if_unique_id_configured()
                 # Input is valid, set data.
                 self.data = user_input
                 # Return the form of the next step.

--- a/custom_components/openplantbook/config_flow.py
+++ b/custom_components/openplantbook/config_flow.py
@@ -101,6 +101,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
 
             if not errors:
+                # Single-account integration: key the entry on the client_id so
+                # a duplicate setup aborts instead of creating a second entry.
+                await self.async_set_unique_id(user_input[CONF_CLIENT_ID])
+                self._abort_if_unique_id_configured()
                 # Input is valid, set data.
                 self.data = user_input
                 # Return the form of the next step.

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -6,6 +6,11 @@ ATTR_ALIAS = "alias"
 ATTR_PLANT_INSTANCE = "plant_instance"
 ATTR_SPECIES = "species"
 ATTR_API = "api"
+
+# hass.data[DOMAIN] keys for the entity layer
+DATA_COMPONENT = "component"
+DATA_SEARCH_ENTITY = "search_entity"
+DATA_SPECIES_ENTITIES = "species_entities"
 ATTR_HOURS = "hours"
 ATTR_INCLUDE = "include"
 ATTR_IMAGE = "image_url"

--- a/custom_components/openplantbook/entity.py
+++ b/custom_components/openplantbook/entity.py
@@ -1,0 +1,93 @@
+"""Entities for the OpenPlantBook integration.
+
+Thin Entity subclasses that replace the legacy state-only pseudo-entities
+(set via hass.states.async_set). They are added through an EntityComponent for
+the integration's own `openplantbook` domain, so they keep the exact same
+entity_ids and attributes as before while gaining unique_ids.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, OPB_ATTR_SEARCH_RESULT, OPB_DISPLAY_PID, OPB_PID
+
+
+class OpenPlantbookSearchResult(Entity):
+    """Persistent entity holding the latest search results.
+
+    State = number of results; attributes = {pid: display_pid}. Replaces the
+    legacy `openplantbook.search_result` pseudo-state.
+    """
+
+    _attr_should_poll = False
+    # Leave the name unset so HA does not inject a `friendly_name` attribute.
+    # Consumers (e.g. examples/GUI.md's search dropdown) iterate the attribute
+    # dict as a {pid: display_pid} mapping, so an extra key would corrupt it.
+    _attr_name = None
+    _attr_has_entity_name = False
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize the search-result entity."""
+        self.entity_id = f"{DOMAIN}.{OPB_ATTR_SEARCH_RESULT}"
+        self._attr_unique_id = f"{entry.entry_id}_{OPB_ATTR_SEARCH_RESULT}"
+        self._count: int = 0
+        self._results: dict[str, str] = {}
+
+    @property
+    def state(self) -> int:
+        """Return the number of search results."""
+        return self._count
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the {pid: display_pid} mapping of the latest search."""
+        return self._results
+
+    @callback
+    def async_update_results(self, count: int, results: dict[str, str]) -> None:
+        """Store the latest search results and write the new state."""
+        self._count = count
+        self._results = results
+        self.async_write_ha_state()
+
+
+class OpenPlantbookSpecies(Entity):
+    """Per-species entity mirroring one cached OpenPlantbook detail result.
+
+    State = display_pid; attributes = the full plant_data dict. Replaces the
+    legacy `openplantbook.<pid>` pseudo-state. Created on fetch, removed when
+    the cache entry expires.
+    """
+
+    _attr_should_poll = False
+    _attr_name = None
+    _attr_has_entity_name = False
+
+    def __init__(
+        self, entry: ConfigEntry, entity_id: str, plant_data: dict[str, Any]
+    ) -> None:
+        """Initialize a species entity with its first fetched data."""
+        self.entity_id = entity_id
+        self._attr_unique_id = f"{entry.entry_id}_{plant_data[OPB_PID]}"
+        self._plant_data: dict[str, Any] = plant_data
+
+    @property
+    def state(self) -> str | None:
+        """Return the display_pid as the entity state."""
+        return self._plant_data.get(OPB_DISPLAY_PID)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the full plant_data dict as attributes."""
+        return self._plant_data
+
+    @callback
+    def async_update_data(self, plant_data: dict[str, Any]) -> None:
+        """Refresh the cached plant_data and write the new state."""
+        self._plant_data = plant_data
+        self.async_write_ha_state()

--- a/custom_components/openplantbook/entity.py
+++ b/custom_components/openplantbook/entity.py
@@ -34,7 +34,12 @@ class OpenPlantbookSearchResult(Entity):
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the search-result entity."""
         self.entity_id = f"{DOMAIN}.{OPB_ATTR_SEARCH_RESULT}"
-        self._attr_unique_id = f"{entry.entry_id}_{OPB_ATTR_SEARCH_RESULT}"
+        # Prefer the config entry's unique_id (the client_id) so the entity
+        # unique_id stays stable if the entry is removed and re-added for the
+        # same account; fall back to entry_id only when it is unset.
+        self._attr_unique_id = (
+            f"{entry.unique_id or entry.entry_id}_{OPB_ATTR_SEARCH_RESULT}"
+        )
         self._count: int = 0
         self._results: dict[str, str] = {}
 
@@ -73,7 +78,10 @@ class OpenPlantbookSpecies(Entity):
     ) -> None:
         """Initialize a species entity with its first fetched data."""
         self.entity_id = entity_id
-        self._attr_unique_id = f"{entry.entry_id}_{plant_data[OPB_PID]}"
+        # See OpenPlantbookSearchResult: prefer the stable client_id prefix.
+        self._attr_unique_id = (
+            f"{entry.unique_id or entry.entry_id}_{plant_data[OPB_PID]}"
+        )
         self._plant_data: dict[str, Any] = plant_data
 
     @property

--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -19,5 +19,6 @@
     "json-timeseries==0.1.7",
     "openplantbook-sdk==0.6.1"
   ],
+  "single_config_entry": true,
   "version": "1.5.0"
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -199,35 +199,30 @@ class TestConfigFlow:
         entries = hass.config_entries.async_entries(DOMAIN)
         assert entries[0].unique_id == "valid_id"
 
-    async def test_duplicate_client_id_aborts(
+    async def test_second_entry_aborts_single_instance(
         self,
         hass: HomeAssistant,
     ) -> None:
-        """A second entry with the same client_id aborts."""
+        """A second config entry is blocked: this is a single-instance integration.
+
+        The shared global hass.data[DOMAIN] (single API client, single
+        search_result entity_id) means a second entry would clobber the first, so
+        `single_config_entry` in the manifest aborts the flow before it starts,
+        regardless of the client_id.
+        """
         existing = MockConfigEntry(
             domain=DOMAIN,
-            data={CONF_CLIENT_ID: "dup_id", CONF_CLIENT_SECRET: "secret"},
-            unique_id="dup_id",
+            data={CONF_CLIENT_ID: "first", CONF_CLIENT_SECRET: "secret"},
+            unique_id="first",
         )
         existing.add_to_hass(hass)
 
-        with patch(
-            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
-        ) as mock_api_class:
-            mock_api = MagicMock()
-            mock_api._async_get_token = AsyncMock(return_value="test_token")
-            mock_api_class.return_value = mock_api
-
-            result = await hass.config_entries.flow.async_init(
-                DOMAIN, context={"source": config_entries.SOURCE_USER}
-            )
-            result = await hass.config_entries.flow.async_configure(
-                result["flow_id"],
-                {CONF_CLIENT_ID: "dup_id", CONF_CLIENT_SECRET: "secret"},
-            )
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
         assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "already_configured"
+        assert result["reason"] == "single_instance_allowed"
 
 
 class TestOptionsFlow:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -167,6 +167,68 @@ class TestConfigFlow:
             assert result["data"][CONF_CLIENT_SECRET] == "valid_secret"
             assert result["options"][FLOW_UPLOAD_DATA] is True
 
+    async def test_created_entry_has_unique_id(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A newly created entry gets the client_id as its unique_id."""
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(return_value="test_token")
+            mock_api_class.return_value = mock_api
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {CONF_CLIENT_ID: "valid_id", CONF_CLIENT_SECRET: "valid_secret"},
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    FLOW_UPLOAD_DATA: False,
+                    FLOW_UPLOAD_HASS_LOCATION_COUNTRY: False,
+                    FLOW_UPLOAD_HASS_LOCATION_COORD: False,
+                },
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert entries[0].unique_id == "valid_id"
+
+    async def test_duplicate_client_id_aborts(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A second entry with the same client_id aborts."""
+        existing = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_CLIENT_ID: "dup_id", CONF_CLIENT_SECRET: "secret"},
+            unique_id="dup_id",
+        )
+        existing.add_to_hass(hass)
+
+        with patch(
+            "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api._async_get_token = AsyncMock(return_value="test_token")
+            mock_api_class.return_value = mock_api
+
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {CONF_CLIENT_ID: "dup_id", CONF_CLIENT_SECRET: "secret"},
+            )
+
+        assert result["type"] == FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
 
 class TestOptionsFlow:
     """Tests for the options flow."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 
 from homeassistant.core import HomeAssistant
@@ -11,7 +12,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.openplantbook.const import (
     ATTR_HOURS,
     ATTR_SPECIES,
+    CACHE_TIME,
     DOMAIN,
+    OPB_ATTR_TIMESTAMP,
     OPB_SERVICE_CLEAN_CACHE,
     OPB_SERVICE_GET,
 )
@@ -191,3 +194,65 @@ async def test_clean_cache_skips_in_flight_sentinel(
     # The completed entry was cleaned; the in-flight sentinel is left intact.
     assert hass.states.get("openplantbook.monstera_deliciosa") is None
     assert hass.data[DOMAIN][ATTR_SPECIES].get("in flight species") == {}
+
+
+async def test_entity_survives_until_last_pid_cache_entry_expires(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """The shared per-pid entity is removed only when its last cache entry expires.
+
+    Two differently-cased inputs resolve to the same pid → one shared entity but
+    two cache keys. Expiring one key must not strand the still-cached other key
+    without its state; the entity is torn down only on the last expiry.
+    """
+    # side_effect (not return_value) so each call yields a DISTINCT dict — else
+    # both cache keys would alias one object and backdating one backdates both.
+    mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+        side_effect=[
+            {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "max_light_lux": 20000,
+                "min_light_lux": 1000,
+            },
+            {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "max_light_lux": 20000,
+                "min_light_lux": 1000,
+            },
+        ]
+    )
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "Monstera Deliciosa"}, blocking=True
+    )
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+    cache = hass.data[DOMAIN][ATTR_SPECIES]
+    assert set(cache) == {"Monstera Deliciosa", "monstera deliciosa"}
+    assert hass.states.get("openplantbook.monstera_deliciosa") is not None
+
+    ent_reg = er.async_get(hass)
+    old = (datetime.now() - timedelta(hours=CACHE_TIME + 1)).isoformat()
+
+    # Expire only the first key (default CACHE_TIME window applies).
+    cache["Monstera Deliciosa"][OPB_ATTR_TIMESTAMP] = old
+    await hass.services.async_call(DOMAIN, OPB_SERVICE_CLEAN_CACHE, {}, blocking=True)
+    await hass.async_block_till_done()
+
+    # The other cache entry is still valid → the entity must survive.
+    assert "Monstera Deliciosa" not in hass.data[DOMAIN][ATTR_SPECIES]
+    assert "monstera deliciosa" in hass.data[DOMAIN][ATTR_SPECIES]
+    assert hass.states.get("openplantbook.monstera_deliciosa") is not None
+    assert ent_reg.async_get("openplantbook.monstera_deliciosa") is not None
+
+    # Expire the last remaining key → entity + registry entry now removed.
+    hass.data[DOMAIN][ATTR_SPECIES]["monstera deliciosa"][OPB_ATTR_TIMESTAMP] = old
+    await hass.services.async_call(DOMAIN, OPB_SERVICE_CLEAN_CACHE, {}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("openplantbook.monstera_deliciosa") is None
+    assert ent_reg.async_get("openplantbook.monstera_deliciosa") is None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -20,11 +20,13 @@ async def test_search_result_entity_has_unique_id(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
 ) -> None:
-    """The search_result entity is registered with a unique_id."""
+    """The search_result entity is registered with a client_id-based unique_id."""
     ent_reg = er.async_get(hass)
     entry = ent_reg.async_get(f"{DOMAIN}.search_result")
     assert entry is not None
-    assert entry.unique_id is not None
+    # unique_id is prefixed with the config entry's unique_id (the client_id),
+    # which the conftest entry backfills to "test_client_id".
+    assert entry.unique_id == "test_client_id_search_result"
 
 
 async def test_search_result_survives_reload(
@@ -51,14 +53,15 @@ async def test_species_entity_has_unique_id(
     init_integration: MockConfigEntry,
     mock_openplantbook_api,
 ) -> None:
-    """A fetched species entity is registered with a unique_id."""
+    """A fetched species entity is registered with a client_id-based unique_id."""
     await hass.services.async_call(
         DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
     )
     ent_reg = er.async_get(hass)
     entry = ent_reg.async_get("openplantbook.monstera_deliciosa")
     assert entry is not None
-    assert entry.unique_id is not None
+    # Prefixed with the config entry's unique_id (client_id), suffixed with pid.
+    assert entry.unique_id == "test_client_id_monstera deliciosa"
 
 
 async def test_species_registry_entry_purged_on_cache_clean(
@@ -112,3 +115,54 @@ async def test_species_entity_updates_on_refetch(
     state = hass.states.get("openplantbook.monstera_deliciosa")
     assert state is not None
     assert state.state == "Monstera deliciosa UPDATED"
+
+
+async def test_species_entity_deduped_by_pid_across_inputs(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """Different service inputs resolving to the same pid map to one entity.
+
+    The entity holder is keyed by the canonical pid, so a second fetch with a
+    differently-cased input updates the existing entity instead of attempting
+    to add a duplicate with the same (already-taken) entity_id/unique_id.
+    """
+    # Both inputs resolve to the same pid; the second carries updated data.
+    mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+        side_effect=[
+            {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "max_light_lux": 20000,
+                "min_light_lux": 1000,
+            },
+            {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa v2",
+                "max_light_lux": 20000,
+                "min_light_lux": 1000,
+            },
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "Monstera Deliciosa"}, blocking=True
+    )
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+
+    # Exactly one registry entry for the shared entity_id...
+    ent_reg = er.async_get(hass)
+    matching = [
+        e
+        for e in ent_reg.entities.values()
+        if e.entity_id == "openplantbook.monstera_deliciosa"
+    ]
+    assert len(matching) == 1
+    # ...and it reflects the second fetch (proving the update path was taken,
+    # not a rejected duplicate add).
+    state = hass.states.get("openplantbook.monstera_deliciosa")
+    assert state is not None
+    assert state.state == "Monstera deliciosa v2"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -256,3 +256,35 @@ async def test_entity_survives_until_last_pid_cache_entry_expires(
 
     assert hass.states.get("openplantbook.monstera_deliciosa") is None
     assert ent_reg.async_get("openplantbook.monstera_deliciosa") is None
+
+
+async def test_stale_species_entities_purged_on_setup(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """Per-species registry entries left over from a previous run are purged at setup.
+
+    The species cache is in-memory, so after a restart it is empty and
+    clean_cache can't expire anything. Setup must clear leftover per-species
+    registry rows so they don't linger as stale, unavailable entities, while
+    keeping the persistent search_result entity.
+    """
+    ent_reg = er.async_get(hass)
+    # Simulate a per-species entity left in the registry by a previous run.
+    ghost = ent_reg.async_get_or_create(
+        domain=DOMAIN,
+        platform=DOMAIN,
+        unique_id="test_client_id_ghost species",
+        suggested_object_id="ghost_species",
+    )
+    assert ent_reg.async_get(ghost.entity_id) is not None
+    assert ent_reg.async_get("openplantbook.search_result") is not None
+
+    # Reload re-runs async_setup_entry, which purges stale per-species entries.
+    await hass.config_entries.async_reload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert ent_reg.async_get(ghost.entity_id) is None
+    # The persistent search_result entity is preserved.
+    assert ent_reg.async_get("openplantbook.search_result") is not None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.openplantbook.const import DOMAIN
+from custom_components.openplantbook.const import (
+    ATTR_HOURS,
+    DOMAIN,
+    OPB_SERVICE_CLEAN_CACHE,
+    OPB_SERVICE_GET,
+)
 
 
 async def test_search_result_entity_has_unique_id(
@@ -37,3 +44,71 @@ async def test_search_result_survives_reload(
     assert after is not None
     assert after.unique_id == before.unique_id
     assert hass.states.get(f"{DOMAIN}.search_result") is not None
+
+
+async def test_species_entity_has_unique_id(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """A fetched species entity is registered with a unique_id."""
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get("openplantbook.monstera_deliciosa")
+    assert entry is not None
+    assert entry.unique_id is not None
+
+
+async def test_species_registry_entry_purged_on_cache_clean(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """Clearing the cache removes the species state AND its registry entry."""
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get("openplantbook.monstera_deliciosa") is not None
+
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_CLEAN_CACHE, {ATTR_HOURS: 0}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("openplantbook.monstera_deliciosa") is None
+    assert ent_reg.async_get("openplantbook.monstera_deliciosa") is None
+
+
+async def test_species_entity_updates_on_refetch(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """Refetching an existing species updates its entity state in place."""
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+    assert hass.states.get("openplantbook.monstera_deliciosa") is not None
+
+    # Return changed data and force a refetch (cache=false) for the same species.
+    mock_openplantbook_api.async_plant_detail_get = AsyncMock(
+        return_value={
+            "pid": "monstera deliciosa",
+            "display_pid": "Monstera deliciosa UPDATED",
+            "max_light_lux": 20000,
+            "min_light_lux": 1000,
+        }
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        OPB_SERVICE_GET,
+        {"species": "monstera deliciosa", "cache": False},
+        blocking=True,
+    )
+
+    state = hass.states.get("openplantbook.monstera_deliciosa")
+    assert state is not None
+    assert state.state == "Monstera deliciosa UPDATED"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,39 @@
+"""Tests for the real OpenPlantbook entities and their unique_ids."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.openplantbook.const import DOMAIN
+
+
+async def test_search_result_entity_has_unique_id(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """The search_result entity is registered with a unique_id."""
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get(f"{DOMAIN}.search_result")
+    assert entry is not None
+    assert entry.unique_id is not None
+
+
+async def test_search_result_survives_reload(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """After a config-entry reload, search_result is re-registered with the same unique_id."""
+    ent_reg = er.async_get(hass)
+    before = ent_reg.async_get(f"{DOMAIN}.search_result")
+    assert before is not None
+
+    await hass.config_entries.async_reload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    after = ent_reg.async_get(f"{DOMAIN}.search_result")
+    assert after is not None
+    assert after.unique_id == before.unique_id
+    assert hass.states.get(f"{DOMAIN}.search_result") is not None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openplantbook.const import (
     ATTR_HOURS,
+    ATTR_SPECIES,
     DOMAIN,
     OPB_SERVICE_CLEAN_CACHE,
     OPB_SERVICE_GET,
@@ -166,3 +167,27 @@ async def test_species_entity_deduped_by_pid_across_inputs(
     state = hass.states.get("openplantbook.monstera_deliciosa")
     assert state is not None
     assert state.state == "Monstera deliciosa v2"
+
+
+async def test_clean_cache_skips_in_flight_sentinel(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_openplantbook_api,
+) -> None:
+    """clean_cache tolerates the in-flight sentinel ({}) left by the concurrency guard."""
+    # A completed entry plus a simulated in-flight sentinel (as get_plant's
+    # concurrency guard would leave mid-fetch).
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_GET, {"species": "monstera deliciosa"}, blocking=True
+    )
+    hass.data[DOMAIN][ATTR_SPECIES]["in flight species"] = {}
+
+    # Must not raise despite the sentinel lacking a timestamp/pid.
+    await hass.services.async_call(
+        DOMAIN, OPB_SERVICE_CLEAN_CACHE, {ATTR_HOURS: 0}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    # The completed entry was cleaned; the in-flight sentinel is left intact.
+    assert hass.states.get("openplantbook.monstera_deliciosa") is None
+    assert hass.data[DOMAIN][ATTR_SPECIES].get("in flight species") == {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,7 +110,18 @@ class TestIntegrationSetup:
         hass: HomeAssistant,
         init_integration: MockConfigEntry,
     ) -> None:
-        """Test async_unload_entry removes services and data."""
+        """Test async_unload_entry removes per-entry data and services.
+
+        After unload, hass.data[DOMAIN] only retains the EntityComponent (which
+        is intentionally kept alive across reloads so entity platform ownership
+        is stable). Per-entry keys such as ATTR_API and ATTR_SPECIES are gone.
+        """
+        from custom_components.openplantbook.const import (
+            ATTR_API,
+            ATTR_SPECIES,
+            DATA_COMPONENT,
+        )
+
         # Verify setup was successful
         assert DOMAIN in hass.data
 
@@ -119,7 +130,11 @@ class TestIntegrationSetup:
         await hass.async_block_till_done()
 
         assert result is True
-        assert DOMAIN not in hass.data
+        # Per-entry data is gone
+        assert ATTR_API not in hass.data.get(DOMAIN, {})
+        assert ATTR_SPECIES not in hass.data.get(DOMAIN, {})
+        # EntityComponent is deliberately retained for reload reuse
+        assert DATA_COMPONENT in hass.data.get(DOMAIN, {})
 
     async def test_services_removed_on_unload(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -145,14 +145,17 @@ class TestIntegrationSetup:
         # Verify services exist
         assert hass.services.has_service(DOMAIN, OPB_SERVICE_SEARCH)
         assert hass.services.has_service(DOMAIN, OPB_SERVICE_GET)
+        assert hass.services.has_service(DOMAIN, OPB_SERVICE_UPLOAD)
 
         # Unload
         await hass.config_entries.async_unload(init_integration.entry_id)
         await hass.async_block_till_done()
 
-        # Services should be removed
+        # All registered services should be removed (including upload)
         assert not hass.services.has_service(DOMAIN, OPB_SERVICE_SEARCH)
         assert not hass.services.has_service(DOMAIN, OPB_SERVICE_GET)
+        assert not hass.services.has_service(DOMAIN, OPB_SERVICE_CLEAN_CACHE)
+        assert not hass.services.has_service(DOMAIN, OPB_SERVICE_UPLOAD)
 
 
 class TestSearchService:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -95,6 +95,16 @@ class TestIntegrationSetup:
         assert hass.services.has_service(DOMAIN, OPB_SERVICE_CLEAN_CACHE)
         assert hass.services.has_service(DOMAIN, OPB_SERVICE_UPLOAD)
 
+    async def test_existing_entry_unique_id_backfilled(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """An entry set up without a unique_id is backfilled to the client_id."""
+        # The conftest mock_config_entry is created without a unique_id, so
+        # async_setup_entry's backfill is what sets it to the client_id.
+        assert init_integration.unique_id == "test_client_id"
+
     async def test_async_unload_entry(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## What

Converts the integration's state-only pseudo-entities into **real registered entities with `unique_id`s**, fixing the missing-unique_id repair warning (#83), and gives the config entry a `unique_id`.

Previously the integration exposed data via the legacy `hass.states.async_set(...)` pattern — unregistered pseudo-entities with no `unique_id`, which recent Home Assistant versions flag with a repair warning.

- `openplantbook.search_result` and `openplantbook.<species>` are now real entities owned in the **`openplantbook` domain** via an `EntityComponent` (the same mechanism `person`/`zone` use). Their **`entity_id`s and attributes are unchanged**, so `examples/GUI.md` and any user dashboard reading `states.openplantbook.search_result.attributes` / `state_attr('openplantbook.<pid>', ...)` keep working — **non-breaking**.
- The dynamic per-species entities **purge their entity-registry entry on cache expiry**, so they don't accumulate as stale "unavailable" entities.
- The config entry gets a `unique_id` (client_id) via the config flow, with a **backfill** for existing installs, and a duplicate setup now aborts.

Closes #83.

## How it works

- `entity.py` defines two thin `Entity` subclasses (`OpenPlantbookSearchResult`, `OpenPlantbookSpecies`). Both set `_attr_name = None` / `_attr_has_entity_name = False` **on purpose** — a name would make HA inject a `friendly_name` attribute that would pollute the `{pid: display_pid}` mapping GUI.md iterates over.
- One `EntityComponent` is created per HA instance and reused across config-entry reloads.
- The `get`/`search`/`clean_cache` services write/remove state through these entities instead of `hass.states.async_set`. The `get` concurrency guard is untouched (it waits on the `hass.data` cache dict, not the state).

## Design notes (intentional scope)

- **No device / config-entry entity linkage** by design: these are machine-managed data carriers, not user-configurable things. Linking the *dynamic* per-species entities to a device would make them accumulate as stale registry entries every time a species' cache expires — so they purge instead.
- **No `strings.json`/translation entries needed** — the entities have `_attr_name = None` (verified no `friendly_name` is emitted), so HA needs no display-name strings.
- Version bump is intentionally **not** included here (handled separately at release time).

## Test Plan

- [x] `pytest tests/` — 92 passing
- [x] `ruff check` + `black --check` clean
- [x] New tests: search_result + per-species entities have `unique_id`s; per-species **registry entry is purged** after `clean_cache` (orphan check); reload re-registers with the same unique_id; refetch updates in place (no duplicate); config-entry `unique_id` set on new entries + backfilled for existing + duplicate aborts.
- [x] Existing `states.get("openplantbook.search_result")` / `openplantbook.<species>` assertions still pass — confirms entity_id + attribute preservation.

## Known non-blocking edge cases

- A pre-existing entry with no stored `CONF_CLIENT_ID` won't get a backfilled `unique_id` (degenerate/unconfigurable case).
- `async_generate_entity_id(..., current_ids={})` doesn't dedup against the live registry — preserved legacy behavior; two species slugifying to the same entity_id would share one (pre-existing, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)