### PR TITLE
chore: release 1.6.0-beta1

### DIFF
--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -20,5 +20,5 @@
     "openplantbook-sdk==0.6.1"
   ],
   "single_config_entry": true,
-  "version": "1.5.0"
+  "version": "1.6.0-beta1"
 }


### PR DESCRIPTION
Beta release **1.6.0-beta1**.

## What's new

- **Real entities with `unique_id`s (#83, #84).** `openplantbook.search_result` and the per-species `openplantbook.<pid>` entities are now real registered entities (owned in the `openplantbook` domain via an `EntityComponent`) instead of state-only pseudo-entities — silencing the "missing unique ID" repair warning. Same entity_ids and attributes, so existing dashboards and `examples/GUI.md` are unaffected.
- The **config entry** now has a `unique_id` (the client_id), backfilled for existing installs, and the integration is marked **single-instance** (`single_config_entry`).
- Per-species entities are cleaned from the registry on cache expiry **and** at setup (so they don't linger as stale entities after a restart).

Merging triggers the Auto Release workflow, which tags `v1.6.0-beta1` and publishes it as a pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)