### PR TITLE
chore: release 1.6.0

### DIFF
--- a/custom_components/openplantbook/manifest.json
+++ b/custom_components/openplantbook/manifest.json
@@ -20,5 +20,5 @@
     "openplantbook-sdk==0.6.1"
   ],
   "single_config_entry": true,
-  "version": "1.6.0-beta1"
+  "version": "1.6.0"
 }


### PR DESCRIPTION
Promotes the real-entities feature from `1.6.0-beta1` to stable `1.6.0`.

## What's new in 1.6.0
- **Real entities with unique IDs** (#84, closes #83): `search_result` and the per-species states are now proper Home Assistant entities with stable `unique_id`s, silencing the "Missing unique ID" warning while preserving the existing `entity_id`s and attributes that `examples/GUI.md` and the species-care display depend on.
- Config entry now sets a `unique_id`; integration marked `single_config_entry`.

Issue #83 confirmed fixed in `1.6.0-beta1` testing.

Version bump only (`manifest.json`). CI handles tagging and the GitHub release.