### PR TITLE
ci: add Dependabot config (grouped actions + pip test tooling)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # GitHub Actions — all action bumps grouped into one weekly PR to limit noise.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python test tooling from requirements.test.txt, grouped so patch/minor
+  # updates land together rather than as many PRs.
+  #
+  # Runtime requirements live in custom_components/openplantbook/manifest.json,
+  # which Dependabot cannot parse — json-timeseries and openplantbook-sdk are
+  # updated manually.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
Adds a Dependabot config, matching the conventions used in the `homeassistant-plant` and `lovelace-flower-card` repos. This repo previously had **no** Dependabot config, and several actions are behind (e.g. `codecov-action@v5`, `actions/github-script@v7`, `softprops/action-gh-release@v2`).

## What it tracks
- **github-actions:** all action bumps grouped into a single weekly PR (prefix `ci`, labelled `dependencies`/`github-actions`).
- **pip:** test tooling from `requirements.test.txt` (pytest, pytest-cov, pytest-homeassistant-custom-component), grouped by patch/minor (prefix `build`, labelled `dependencies`/`python`).

## Notes
- Runtime requirements live in `custom_components/openplantbook/manifest.json`, which **Dependabot cannot parse**. `json-timeseries` and `openplantbook-sdk` therefore stay manual — see the follow-up discussion on monitoring those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)