### PR TITLE
ci: monitor manifest dependencies (PyPI freshness + HA-core guard)

### DIFF
--- a/.github/workflows/manifest-deps.yml
+++ b/.github/workflows/manifest-deps.yml
@@ -1,0 +1,78 @@
+name: Manifest dependency monitoring
+
+# Informs (does not edit) when a pinned manifest.json requirement has a newer
+# release on PyPI, by maintaining a single GitHub issue. The manifest stays the
+# hand-edited source of truth.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  freshness:
+    name: Check manifest dependency freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install packaging
+
+      - name: Check freshness
+        id: check
+        env:
+          FRESHNESS_BODY: manifest_freshness_body.md
+        run: python scripts/check_manifest_freshness.py
+
+      - name: Manage tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ steps.check.outputs.count }}
+          BODY_FILE: manifest_freshness_body.md
+          LABEL: dependency-freshness
+          TITLE: "Manifest dependency updates available"
+        run: |
+          set -euo pipefail
+
+          # Ensure the tracking label exists (idempotent).
+          gh label create "$LABEL" \
+            --color FBCA04 \
+            --description "Available updates for manifest.json requirements" \
+            --force >/dev/null 2>&1 || true
+
+          # Find the existing managed issue, if any (open or closed).
+          number=$(gh issue list --label "$LABEL" --state all --limit 1 \
+            --json number --jq '.[0].number // empty')
+
+          if [ "${COUNT:-0}" -gt 0 ]; then
+            if [ -n "$number" ]; then
+              gh issue reopen "$number" >/dev/null 2>&1 || true
+              gh issue edit "$number" --body-file "$BODY_FILE" >/dev/null
+              echo "Updated tracking issue #$number"
+            else
+              gh issue create --title "$TITLE" --label "$LABEL" \
+                --body-file "$BODY_FILE"
+            fi
+          else
+            if [ -n "$number" ]; then
+              state=$(gh issue view "$number" --json state --jq .state)
+              if [ "$state" = "OPEN" ]; then
+                gh issue comment "$number" \
+                  --body "All manifest dependencies are up to date. Closing."
+                gh issue close "$number" >/dev/null
+                echo "Closed tracking issue #$number"
+              fi
+            fi
+            echo "All pinned manifest dependencies are up to date."
+          fi

--- a/scripts/check_manifest_freshness.py
+++ b/scripts/check_manifest_freshness.py
@@ -33,6 +33,19 @@ DEFAULT_MANIFEST = (
 PYPI_URL = "https://pypi.org/pypi/{name}/json"
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects, so a request can't leave the guarded URL."""
+
+    def redirect_request(self, *args, **kwargs):  # noqa: D102
+        return None
+
+
+# Opener that does not follow redirects: combined with the https://pypi.org/
+# guard in fetch_latest_pypi, the request can only ever reach PyPI over https.
+# Any 3xx surfaces as a non-200 status and is treated as a failed lookup.
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
 @dataclass(frozen=True)
 class Outdated:
     """A pinned requirement that has a newer release on PyPI."""
@@ -96,9 +109,10 @@ def fetch_latest_pypi(name: str) -> str | None:
     request = urllib.request.Request(url, method="GET")
     try:
         # URL is a constant https PyPI endpoint with a canonicalised package
-        # name from our own manifest, and is guarded above; not user input.
+        # name from our own manifest, guarded above, and redirects are refused
+        # by _OPENER; not user input and can't leave pypi.org.
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-        with urllib.request.urlopen(request, timeout=30) as resp:
+        with _OPENER.open(request, timeout=30) as resp:
             if resp.status != 200:
                 return None
             data = json.load(resp)

--- a/scripts/check_manifest_freshness.py
+++ b/scripts/check_manifest_freshness.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check manifest.json runtime requirements against the latest PyPI releases.
+
+Reads the integration manifest, and for every requirement pinned with an exact
+``==`` version, looks up the latest stable release on PyPI. Requirements that
+are not exactly pinned (ranges, no version) are skipped.
+
+This script only *reports*; it never edits the manifest. It is run by the
+``manifest-deps`` workflow, which turns the result into a single GitHub issue.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "openplantbook"
+    / "manifest.json"
+)
+PYPI_URL = "https://pypi.org/pypi/{name}/json"
+
+
+@dataclass(frozen=True)
+class Outdated:
+    """A pinned requirement that has a newer release on PyPI."""
+
+    name: str
+    current: str
+    latest: str
+
+
+def pinned_requirements(manifest: dict) -> list[tuple[str, str]]:
+    """Return ``(name, version)`` for requirements pinned with an exact ``==``.
+
+    Requirements without a single ``==`` pin (ranges, ``>=``, unpinned) are
+    skipped — there is no single "current" version to compare against.
+    """
+    pins: list[tuple[str, str]] = []
+    for raw in manifest.get("requirements", []):
+        req = Requirement(raw)
+        specs = list(req.specifier)
+        if len(specs) == 1 and specs[0].operator == "==":
+            pins.append((req.name, specs[0].version))
+    return pins
+
+
+def find_outdated(
+    pins: list[tuple[str, str]],
+    fetch_latest: Callable[[str], str | None],
+) -> list[Outdated]:
+    """Return the subset of ``pins`` whose latest PyPI release is newer.
+
+    ``fetch_latest`` maps a package name to its latest stable version string,
+    or ``None`` when the lookup failed (network error, unknown package, bad
+    version). Failures are skipped, never reported as outdated.
+    """
+    outdated: list[Outdated] = []
+    for name, current in pins:
+        latest = fetch_latest(name)
+        if latest is None:
+            continue
+        try:
+            if Version(latest) > Version(current):
+                outdated.append(Outdated(name=name, current=current, latest=latest))
+        except InvalidVersion:
+            continue
+    return outdated
+
+
+def fetch_latest_pypi(name: str) -> str | None:
+    """Return the latest stable version of ``name`` on PyPI, or ``None``.
+
+    Uses PyPI's ``info.version``, which is the latest non-prerelease,
+    non-yanked release. Any network/parse error returns ``None`` so a transient
+    outage never fails the caller.
+    """
+    url = PYPI_URL.format(name=canonicalize_name(name))
+    # Defensive: the name is canonicalised and the base is a constant, but
+    # never let urllib follow anything other than an https PyPI URL (no
+    # file://, no other host).
+    if not url.startswith("https://pypi.org/"):
+        return None
+    request = urllib.request.Request(url, method="GET")
+    try:
+        # URL is a constant https PyPI endpoint with a canonicalised package
+        # name from our own manifest, and is guarded above; not user input.
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with urllib.request.urlopen(request, timeout=30) as resp:
+            if resp.status != 200:
+                return None
+            data = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+        return None
+    version = data.get("info", {}).get("version")
+    return version or None
+
+
+def render_issue_body(outdated: list[Outdated]) -> str:
+    """Render the GitHub issue body listing outdated dependencies."""
+    lines = [
+        "The following `manifest.json` requirements have newer releases on PyPI.",
+        "",
+        "Update the pin in `custom_components/openplantbook/manifest.json` by "
+        "hand after verifying compatibility — this issue is informational and "
+        "closes automatically once everything is current.",
+        "",
+        "| Package | Pinned | Latest |",
+        "| --- | --- | --- |",
+    ]
+    for item in sorted(outdated, key=lambda o: o.name):
+        lines.append(f"| `{item.name}` | {item.current} | {item.latest} |")
+    return "\n".join(lines) + "\n"
+
+
+def _set_output(name: str, value: str) -> None:
+    """Append ``name=value`` to the GitHub Actions output file, if present."""
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: print a summary, write the issue body, and set ``count`` output."""
+    argv = sys.argv[1:] if argv is None else argv
+    manifest_path = Path(argv[0]) if argv else DEFAULT_MANIFEST
+    body_path = Path(os.environ.get("FRESHNESS_BODY", "manifest_freshness_body.md"))
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    pins = pinned_requirements(manifest)
+    outdated = find_outdated(pins, fetch_latest_pypi)
+
+    if outdated:
+        body = render_issue_body(outdated)
+        body_path.write_text(body, encoding="utf-8")
+        print(f"{len(outdated)} outdated requirement(s):")
+        for item in outdated:
+            print(f"  {item.name}: {item.current} -> {item.latest}")
+    else:
+        print(f"All {len(pins)} pinned requirement(s) are up to date.")
+
+    _set_output("count", str(len(outdated)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_manifest_ha_compat.py
+++ b/scripts/check_manifest_ha_compat.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check manifest pins against Home Assistant core's pinned constraints.
+
+For any manifest requirement whose package is also pinned by Home Assistant
+core (``homeassistant/package_constraints.txt``), the manifest pin must be
+satisfied by HA's version — otherwise HA would override or reject our pin at
+runtime. Packages not present in HA core are ignored.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+# importlib.resources is the standard modern API; this project targets
+# Python 3.13, so the 3.7-backcompat warning does not apply.
+from importlib.resources import (  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
+    files,
+)
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "openplantbook"
+    / "manifest.json"
+)
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """A manifest pin that conflicts with HA core's constraint."""
+
+    requirement: str
+    ha_version: str
+
+
+def parse_constraints(text: str) -> dict[str, str]:
+    """Parse ``name==version`` lines from an HA constraints file.
+
+    Comments, blank lines, and any line that is not a single ``==`` pin are
+    ignored. Names are canonicalised so lookups are normalisation-insensitive.
+    """
+    constraints: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        try:
+            req = Requirement(line)
+        except Exception:  # noqa: BLE001 - skip anything non-standard
+            continue
+        specs = list(req.specifier)
+        if len(specs) == 1 and specs[0].operator == "==":
+            constraints[canonicalize_name(req.name)] = specs[0].version
+    return constraints
+
+
+def find_constraint_mismatches(
+    requirements: list[str],
+    constraints: dict[str, str],
+) -> list[Mismatch]:
+    """Return manifest requirements whose pin conflicts with HA core.
+
+    Only requirements whose canonical name appears in ``constraints`` are
+    considered; a conflict is when HA's pinned version does not satisfy our
+    specifier.
+    """
+    mismatches: list[Mismatch] = []
+    for raw in requirements:
+        req = Requirement(raw)
+        ha_version = constraints.get(canonicalize_name(req.name))
+        if ha_version is None:
+            continue
+        if not req.specifier.contains(ha_version, prereleases=True):
+            mismatches.append(Mismatch(requirement=raw, ha_version=ha_version))
+    return mismatches
+
+
+def ha_core_constraints() -> dict[str, str] | None:
+    """Return HA core's pinned constraints, or ``None`` if unavailable."""
+    try:
+        text = (
+            files("homeassistant")
+            .joinpath("package_constraints.txt")
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    return parse_constraints(text)
+
+
+def manifest_requirements(manifest_path: Path = DEFAULT_MANIFEST) -> list[str]:
+    """Return the raw requirement strings from the manifest."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return list(manifest.get("requirements", []))

--- a/tests/test_check_manifest_freshness.py
+++ b/tests/test_check_manifest_freshness.py
@@ -1,0 +1,78 @@
+"""Unit tests for the manifest freshness checker (pure logic)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The checker lives in scripts/, which is not a package on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_manifest_freshness import (  # noqa: E402
+    Outdated,
+    find_outdated,
+    pinned_requirements,
+    render_issue_body,
+)
+
+
+def test_pinned_requirements_keeps_only_exact_pins():
+    """Only requirements with a single == specifier are returned."""
+    manifest = {
+        "requirements": [
+            "openplantbook-sdk==0.6.1",
+            "json-timeseries==0.1.7",
+            "async-timeout>=4.0.2",  # range -> skipped
+            "some-pkg",  # unpinned -> skipped
+            "other>=1.0,<2.0",  # multi-spec -> skipped
+        ]
+    }
+    assert pinned_requirements(manifest) == [
+        ("openplantbook-sdk", "0.6.1"),
+        ("json-timeseries", "0.1.7"),
+    ]
+
+
+def test_pinned_requirements_empty_when_no_requirements():
+    """A manifest with no requirements yields no pins."""
+    assert pinned_requirements({}) == []
+
+
+def test_find_outdated_reports_newer_releases():
+    """A package whose latest release is newer than the pin is flagged."""
+    pins = [("openplantbook-sdk", "0.6.1")]
+    outdated = find_outdated(pins, lambda name: "0.7.0")
+    assert outdated == [Outdated("openplantbook-sdk", "0.6.1", "0.7.0")]
+
+
+def test_find_outdated_ignores_up_to_date_and_older():
+    """Equal or older latest versions are not reported."""
+    pins = [("a", "1.2.3"), ("b", "2.0.0")]
+    latest = {"a": "1.2.3", "b": "1.9.9"}
+    assert find_outdated(pins, latest.get) == []
+
+
+def test_find_outdated_skips_lookup_failures():
+    """A None from the fetcher (network error / unknown) is skipped, not flagged."""
+    pins = [("a", "1.0.0"), ("b", "1.0.0")]
+    latest = {"a": None, "b": "2.0.0"}
+    assert find_outdated(pins, latest.get) == [Outdated("b", "1.0.0", "2.0.0")]
+
+
+def test_find_outdated_skips_unparseable_latest():
+    """A non-PEP440 latest string is skipped rather than raising."""
+    pins = [("a", "1.0.0")]
+    assert find_outdated(pins, lambda name: "not-a-version") == []
+
+
+def test_render_issue_body_lists_packages_sorted():
+    """The issue body renders a Markdown table sorted by package name."""
+    body = render_issue_body(
+        [
+            Outdated("zlib-pkg", "1.0", "1.1"),
+            Outdated("alpha-pkg", "2.0", "3.0"),
+        ]
+    )
+    assert "| `alpha-pkg` | 2.0 | 3.0 |" in body
+    assert "| `zlib-pkg` | 1.0 | 1.1 |" in body
+    assert body.index("alpha-pkg") < body.index("zlib-pkg")

--- a/tests/test_check_manifest_freshness.py
+++ b/tests/test_check_manifest_freshness.py
@@ -2,13 +2,7 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-# The checker lives in scripts/, which is not a package on the path.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-
-from check_manifest_freshness import (  # noqa: E402
+from scripts.check_manifest_freshness import (
     Outdated,
     find_outdated,
     pinned_requirements,

--- a/tests/test_manifest_ha_compat.py
+++ b/tests/test_manifest_ha_compat.py
@@ -1,0 +1,86 @@
+"""Tests for the manifest <-> HA-core compatibility guard."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# The checker lives in scripts/, which is not a package on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_manifest_ha_compat import (  # noqa: E402
+    Mismatch,
+    find_constraint_mismatches,
+    ha_core_constraints,
+    manifest_requirements,
+    parse_constraints,
+)
+
+
+def test_parse_constraints_extracts_exact_pins():
+    """Only single == pins are parsed; comments and blanks are ignored."""
+    text = (
+        "# generated, do not edit\n"
+        "aiohttp==3.13.5\n"
+        "\n"
+        "async-timeout==4.0.3\n"
+        "voluptuous>=0.12\n"  # not an exact pin -> skipped
+    )
+    assert parse_constraints(text) == {
+        "aiohttp": "3.13.5",
+        "async-timeout": "4.0.3",
+    }
+
+
+def test_no_mismatch_when_package_absent_from_ha():
+    """Packages HA core does not pin are ignored (the OPB SDK case)."""
+    mismatches = find_constraint_mismatches(
+        ["openplantbook-sdk==0.6.1"],
+        {"aiohttp": "3.13.5"},
+    )
+    assert mismatches == []
+
+
+def test_no_mismatch_when_ha_version_satisfies_specifier():
+    """A range that contains HA's pinned version is fine."""
+    mismatches = find_constraint_mismatches(
+        ["async-timeout>=4.0.2"],
+        {"async-timeout": "4.0.3"},
+    )
+    assert mismatches == []
+
+
+def test_mismatch_detected_when_pin_conflicts_with_ha():
+    """An exact pin that differs from HA's pinned version is flagged."""
+    mismatches = find_constraint_mismatches(
+        ["async-timeout==4.0.2"],
+        {"async-timeout": "4.0.3"},
+    )
+    assert mismatches == [Mismatch("async-timeout==4.0.2", "4.0.3")]
+
+
+def test_mismatch_uses_canonicalized_names():
+    """Name normalisation (underscore/case) does not hide a conflict."""
+    mismatches = find_constraint_mismatches(
+        ["Foo_Bar==1.0"],
+        {"foo-bar": "2.0"},
+    )
+    assert mismatches == [Mismatch("Foo_Bar==1.0", "2.0")]
+
+
+def test_real_manifest_pins_are_compatible_with_installed_ha():
+    """The actual manifest must not conflict with the installed HA core.
+
+    Runs against whatever HA the test matrix installed (the 'latest' leg checks
+    the latest HA release). Skips if the constraints file is unavailable.
+    """
+    constraints = ha_core_constraints()
+    if constraints is None:
+        pytest.skip("Home Assistant package_constraints.txt not available")
+    mismatches = find_constraint_mismatches(manifest_requirements(), constraints)
+    assert not mismatches, (
+        "manifest.json pins conflict with Home Assistant core constraints: "
+        + ", ".join(f"{m.requirement} (HA pins {m.ha_version})" for m in mismatches)
+    )

--- a/tests/test_manifest_ha_compat.py
+++ b/tests/test_manifest_ha_compat.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
-# The checker lives in scripts/, which is not a package on the path.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-
-from check_manifest_ha_compat import (  # noqa: E402
+from scripts.check_manifest_ha_compat import (
     Mismatch,
     find_constraint_mismatches,
     ha_core_constraints,


### PR DESCRIPTION
`manifest.json` runtime requirements (`json-timeseries`, `openplantbook-sdk`) are invisible to Dependabot — no ecosystem parses HA's manifest. This adds two lightweight checks while keeping `manifest.json` the **hand-edited source of truth** (nothing auto-edits it).

## 1. PyPI freshness → single GitHub issue (inform-only)
- `scripts/check_manifest_freshness.py` — for each requirement pinned with an exact `==`, looks up the latest stable PyPI release. Ranges/unpinned are skipped; network errors are skipped (never a false alarm).
- `.github/workflows/manifest-deps.yml` — runs **daily** (+ manual dispatch) and maintains exactly **one** issue via a dedicated `dependency-freshness` label: opens/updates it when something is behind, closes it when everything is current. `permissions: issues: write`.

This replaces the need for Dependabot on these deps: you get notified, then bump the manifest yourself.

## 2. HA-core compatibility guard
- `scripts/check_manifest_ha_compat.py` + `tests/test_manifest_ha_compat.py` — fails CI if a manifest pin conflicts with the version **Home Assistant core** pins for that same package (read from HA's shipped `package_constraints.txt`). No-op for packages not in HA core (the OPB SDK today), so it's a future-proof guard. Runs in the existing test matrix, so the `latest` leg checks against the latest HA release.

## Testing
- Pure-logic unit tests for both (`tests/test_check_manifest_freshness.py`, `tests/test_manifest_ha_compat.py`): outdated / up-to-date / range-skipped / network-error, and constraint-conflict detection + the real manifest vs installed HA. **109 tests pass** locally; script verified against live PyPI (both up-to-date and outdated paths).

## Notes
- Two semgrep findings on the freshness script are suppressed inline with justification: the `urllib` call is guarded to an `https://pypi.org/` URL built from our own manifest, and `importlib.resources` is fine on this 3.13-targeted project.
- Follow-up option: replicate the HA-core guard to `homeassistant-plant` (its `async-timeout` is an HA-core dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)