### PR TITLE
ci: expand ruff to HA-aligned ruleset + flow-translation coverage test

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -7,6 +7,7 @@ import re
 import urllib.parse
 from asyncio import timeout as async_timeout
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import voluptuous as vol
 from homeassistant import exceptions
@@ -249,7 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 ) from err
             except PermissionError as err:
                 plant_data = None
-                _LOGGER.error(
+                _LOGGER.exception(
                     "Authentication failed while fetching data for %s. Please reconfigure the integration",
                     species,
                 )
@@ -257,7 +258,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise InvalidAuth("Authentication failed") from err
             except MissingClientIdOrSecret:
                 plant_data = None
-                _LOGGER.error(
+                _LOGGER.exception(
                     "Missing client ID or secret. Please set up the integration again"
                 )
                 del hass.data[DOMAIN][ATTR_SPECIES][species]
@@ -280,19 +281,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     # saved filename stays stable across refreshes.
                     filename = slugify(
                         urllib.parse.unquote(
-                            os.path.basename(
+                            Path(
                                 urllib.parse.urlparse(plant_data[ATTR_IMAGE]).path
-                            )
+                            ).name
                         ),
                         separator=" ",
                     ).replace(" jpg", ".jpg")
                     raise_if_invalid_filename(filename)
                     download_path = entry.options.get(FLOW_DOWNLOAD_PATH)
-                    if not os.path.isabs(download_path):
+                    if not Path(download_path).is_absolute():
                         download_path = hass.config.path(download_path)
 
-                    final_path = os.path.join(download_path, filename)
-                    if os.path.isfile(final_path):
+                    final_path = str(Path(download_path) / filename)
+                    if await hass.async_add_executor_job(Path(final_path).is_file):
                         _LOGGER.warning("Filename %s already exists", final_path)
                         downloaded_file = final_path
                     else:
@@ -326,7 +327,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 return plant_data
             del hass.data[DOMAIN][ATTR_SPECIES][species]
             return {}
-        elif OPB_PID not in hass.data[DOMAIN][ATTR_SPECIES][species]:
+        if OPB_PID not in hass.data[DOMAIN][ATTR_SPECIES][species]:
             # If more than one "get_plant" is triggered for the same species, we wait for up to
             # 10 seconds for the first process to complete the API request.
             # We don't want to return immediately, as we want the state object to be set by
@@ -353,17 +354,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await asyncio.sleep(1)
             _LOGGER.debug("The other process completed successfully")
             return hass.data[DOMAIN][ATTR_SPECIES][species]
-        elif datetime.now() < datetime.fromisoformat(
+        if datetime.now() < datetime.fromisoformat(
             hass.data[DOMAIN][ATTR_SPECIES][species][OPB_ATTR_TIMESTAMP]
         ) + timedelta(hours=CACHE_TIME):
             # We already have the data we need, so let's just return
             _LOGGER.debug("We already have cached data for %s", species)
             return hass.data[DOMAIN][ATTR_SPECIES][species]
-        else:
-            del hass.data[DOMAIN][ATTR_SPECIES][species]
-            raise OpenPlantbookException(
-                "an unknown error occurred while fetching data for species %s", species
-            )
+        del hass.data[DOMAIN][ATTR_SPECIES][species]
+        raise OpenPlantbookException(
+            "an unknown error occurred while fetching data for species %s", species
+        )
 
     async def search_plantbook(call: ServiceCall) -> ServiceResponse:
         if DOMAIN not in hass.data:
@@ -383,13 +383,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "OpenPlantbook API rate limit exceeded. Please try again later."
             ) from err
         except PermissionError as err:
-            _LOGGER.error(
+            _LOGGER.exception(
                 "Authentication failed while searching for %s. Please reconfigure the integration",
                 alias,
             )
             raise InvalidAuth("Authentication failed") from err
         except MissingClientIdOrSecret:
-            _LOGGER.error(
+            _LOGGER.exception(
                 "Missing client ID or secret. Please set up the integration again"
             )
             raise
@@ -452,7 +452,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def _write_file(path: str, data: bytes) -> None:
         """Write binary data to a file (runs in executor)."""
-        with open(path, "wb") as fil:
+        with Path(path).open("wb") as fil:
             fil.write(data)
 
     async def async_download_image(url: str, download_to: str) -> str | bool:

--- a/custom_components/openplantbook/config_flow.py
+++ b/custom_components/openplantbook/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-import os
+from pathlib import Path
 from typing import Any
 
 import voluptuous as vol
@@ -63,10 +63,12 @@ async def validate_input(hass: core.HomeAssistant, data: dict) -> dict[str, str]
         raise ValueError from ex
     # If any of credentials are empty
     except (KeyError, MissingClientIdOrSecret) as ex:
+        # Logs the exception object, not any credential value (false positive).
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         _LOGGER.debug("API client_id and/or client secret are invalid: %s", ex)
         raise ValueError from ex
-    except Exception as ex:
-        _LOGGER.error("Unable to connect to OpenPlantbook: %s", ex)
+    except Exception:
+        _LOGGER.exception("Unable to connect to OpenPlantbook")
         raise
 
     return {TITLE: "Openplantbook API"}
@@ -217,10 +219,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             return True
         download_path = user_input.get(FLOW_DOWNLOAD_PATH)
         # If path is relative, we assume relative to Home Assistant config dir
-        if not os.path.isabs(download_path):
+        if not Path(download_path).is_absolute():
             download_path = self.hass.config.path(download_path)
 
-        if not os.path.isdir(download_path):
+        if not await self.hass.async_add_executor_job(Path(download_path).is_dir):
             _LOGGER.error(
                 "Download path %s is invalid",
                 download_path,

--- a/custom_components/openplantbook/uploader.py
+++ b/custom_components/openplantbook/uploader.py
@@ -158,7 +158,7 @@ async def plant_data_upload(
 
     plant_devices = []
     # Looking for Plant-component's devices
-    for i, d in device_reg.devices.data.items():
+    for d in device_reg.devices.data.values():
         if "plant" in str(d.identifiers) and d.name_by_user is None:
             plant_devices.append(d)
 
@@ -236,7 +236,7 @@ async def plant_data_upload(
                         search_text=opb_pid
                     )
 
-                    if search_res["count"] == 1:
+                    if search_res["count"] == 1:  # noqa: SIM102 - clearer as nested
                         if opb_pid == search_res["results"][0]["display_pid"]:
                             opb_disp_pid = opb_pid
                             opb_pid = search_res["results"][0]["pid"]
@@ -295,7 +295,7 @@ async def plant_data_upload(
             # Get OpenPlantbook generated ID for the Plant-instance
             custom_id = res[0]["id"]
         except (IndexError, KeyError, TypeError):
-            _LOGGER.error("Cannot parse API response: %s", res)
+            _LOGGER.exception("Cannot parse API response: %s", res)
             continue
 
         # Get the latest_data timestamp from OPB response
@@ -422,33 +422,32 @@ async def plant_data_upload(
             "successful" if res else "failure",
         )
         return {"result": res}
+    _LOGGER.info("Found no sensors data to upload")
+
+    if latest_data:
+        days_since_upload = dt_util.now(dt.UTC) - dt_util.parse_datetime(
+            latest_data
+        ).astimezone(dt.UTC)
+        if (days_since_upload.days > 3) and dt_util.now(dt.UTC).weekday() == 4:
+            _LOGGER.warning(
+                "The last time plant sensors data was successfully uploaded %s days ago. This may indicate a "
+                "problem with Plants sensors or this integration. Please enable OpenPlantbook integration's debug "
+                "logging for more information. "
+                "You may report this issue via GitHub or support@plantbook.io attaching the debug log if you "
+                "believe it is a bug.",
+                days_since_upload.days,
+            )
     else:
-        _LOGGER.info("Found no sensors data to upload")
+        # no latest_data in the OPB API indicates that the data has never been uploaded successfully for the plant
+        if dt_util.now(dt.UTC).weekday() == 6:
+            _LOGGER.warning(
+                "Plants sensors data has never been uploaded successfully. This may indicate a problem with the sensors "
+                "or this integration. Please enable OpenPlantbook integration's debug logging for more information. "
+                "You may report this issue via GitHub or support@plantbook.io attaching the debug log if you "
+                "believe it is a bug."
+            )
 
-        if latest_data:
-            days_since_upload = dt_util.now(dt.UTC) - dt_util.parse_datetime(
-                latest_data
-            ).astimezone(dt.UTC)
-            if (days_since_upload.days > 3) and dt_util.now(dt.UTC).weekday() == 4:
-                _LOGGER.warning(
-                    "The last time plant sensors data was successfully uploaded %s days ago. This may indicate a "
-                    "problem with Plants sensors or this integration. Please enable OpenPlantbook integration's debug "
-                    "logging for more information. "
-                    "You may report this issue via GitHub or support@plantbook.io attaching the debug log if you "
-                    "believe it is a bug.",
-                    days_since_upload.days,
-                )
-        else:
-            # no latest_data in the OPB API indicates that the data has never been uploaded successfully for the plant
-            if dt_util.now(dt.UTC).weekday() == 6:
-                _LOGGER.warning(
-                    "Plants sensors data has never been uploaded successfully. This may indicate a problem with the sensors "
-                    "or this integration. Please enable OpenPlantbook integration's debug logging for more information. "
-                    "You may report this issue via GitHub or support@plantbook.io attaching the debug log if you "
-                    "believe it is a bug."
-                )
-
-        return None
+    return None
 
 
 async def async_setup_upload_schedule(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,4 @@ known-first-party = ["custom_components.openplantbook"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["E402"]  # Allow imports not at top of file in tests
+"scripts/*" = ["T201"]  # CLI helper scripts print to stdout by design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,33 @@ target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]
+# Aligned with the rule groups Home Assistant core enforces via ruff. The
+# HA-specific *pylint* plugins (type-hint/layout/translation checks) live in
+# the core repo and aren't usable here, so this is the portable equivalent.
 select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
     "F",      # pyflakes
     "I",      # isort
     "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "SIM",    # flake8-simplify
+    "RET",    # flake8-return
+    "RUF",    # ruff-specific rules
+    "ASYNC",  # flake8-async (blocking calls in async code)
+    "PTH",    # flake8-use-pathlib
+    "LOG",    # flake8-logging
+    "G",      # flake8-logging-format
+    "T20",    # flake8-print
+    "INP",    # flake8-no-pep420 (missing __init__)
+    "TRY",    # tryceratops
 ]
 ignore = [
-    "E501",   # line too long (handled by black)
+    "E501",    # line too long (handled by black)
+    "TRY003",  # long messages in exceptions (HA core disables this too)
+    "RUF002",  # ambiguous unicode in docstrings (intentional, e.g. « » °)
+    "RUF003",  # ambiguous unicode in comments (intentional)
 ]
 
 [tool.ruff.lint.isort]

--- a/scripts/check_manifest_freshness.py
+++ b/scripts/check_manifest_freshness.py
@@ -36,7 +36,7 @@ PYPI_URL = "https://pypi.org/pypi/{name}/json"
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     """Refuse to follow redirects, so a request can't leave the guarded URL."""
 
-    def redirect_request(self, *args, **kwargs):  # noqa: D102
+    def redirect_request(self, *args, **kwargs):
         return None
 
 
@@ -143,7 +143,7 @@ def _set_output(name: str, value: str) -> None:
     """Append ``name=value`` to the GitHub Actions output file, if present."""
     output = os.environ.get("GITHUB_OUTPUT")
     if output:
-        with open(output, "a", encoding="utf-8") as handle:
+        with Path(output).open("a", encoding="utf-8") as handle:
             handle.write(f"{name}={value}\n")
 
 

--- a/scripts/check_manifest_ha_compat.py
+++ b/scripts/check_manifest_ha_compat.py
@@ -51,7 +51,7 @@ def parse_constraints(text: str) -> dict[str, str]:
             continue
         try:
             req = Requirement(line)
-        except Exception:  # noqa: BLE001 - skip anything non-standard
+        except Exception:
             continue
         specs = list(req.specifier)
         if len(specs) == 1 and specs[0].operator == "==":

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,92 @@
+"""Verify every config/options flow form field is translated.
+
+Mirrors Home Assistant core's flow-translation pylint checks
+(config-flow-field-not-translated / options-flow-field-not-translated): every
+voluptuous field in a flow step must have a ``<flow>.step.<step>.data.<field>``
+entry. We additionally require the same entry in ``translations/en.json`` (what
+HA actually reads at runtime), not just ``strings.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.openplantbook.const import DOMAIN
+
+COMPONENT = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "openplantbook"
+)
+
+
+def _load(name: str) -> dict:
+    return json.loads((COMPONENT / name).read_text(encoding="utf-8"))
+
+
+def _field_names(data_schema) -> set[str]:
+    """Return the field keys of a voluptuous schema (markers or plain keys)."""
+    return {str(getattr(marker, "schema", marker)) for marker in data_schema.schema}
+
+
+def _translated_keys(translations: dict, flow: str, step: str) -> set[str]:
+    node = translations.get(flow, {}).get("step", {}).get(step, {})
+    keys = set(node.get("data", {}).keys())
+    for section in node.get("sections", {}).values():
+        keys |= set(section.get("data", {}).keys())
+    return keys
+
+
+def _assert_step_translated(flow: str, step: str, data_schema) -> None:
+    fields = _field_names(data_schema)
+    for filename, data in (
+        ("strings.json", _load("strings.json")),
+        ("translations/en.json", _load("translations/en.json")),
+    ):
+        missing = fields - _translated_keys(data, flow, step)
+        assert not missing, (
+            f"{filename}: {flow}.step.{step} is missing data labels for "
+            f"{sorted(missing)}"
+        )
+
+
+async def test_config_flow_fields_translated(hass: HomeAssistant) -> None:
+    """Every config flow step's form fields are translated."""
+    with patch(
+        "custom_components.openplantbook.config_flow.OpenPlantBookApi"
+    ) as mock_api_class:
+        mock_api = MagicMock()
+        mock_api._async_get_token = AsyncMock(return_value="test_token")
+        mock_api_class.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "user"
+        _assert_step_translated("config", "user", result["data_schema"])
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_CLIENT_ID: "valid_id", CONF_CLIENT_SECRET: "valid_secret"},
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "upload"
+        _assert_step_translated("config", "upload", result["data_schema"])
+
+
+async def test_options_flow_fields_translated(
+    hass: HomeAssistant,
+    mock_openplantbook_api: MagicMock,
+    init_integration,
+) -> None:
+    """Every options flow step's form fields are translated."""
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+    _assert_step_translated("options", "init", result["data_schema"])


### PR DESCRIPTION
Follow-up to the translation audit (HA epic [home-assistant/epics#76]). HA's HA-specific checks are **pylint plugins internal to `homeassistant/core`** — not packaged or usable in a custom component (path/version coupling). This adopts the **portable equivalent**: HA core has migrated most linting to `ruff`, so we expand our ruff ruleset to match, plus a targeted test for the one pylint-only check that bit us (flow-field translations).

## 1. Expanded ruff ruleset (`pyproject.toml`)
Added the HA-aligned groups: `B, C4, SIM, RET, RUF, ASYNC, PTH, LOG, G, T20, INP, TRY` (on top of `E,W,F,I,UP`). Ignored the noisy ones HA itself disables (`TRY003`) and intentional unicode (`RUF002/003`).

Fixed all resulting findings:
- **`ASYNC240`** (the highest-value): two blocking `os.path` calls in async paths now run via `async_add_executor_job` — the image-download `is_file` check and the options download-path `is_dir` check.
- **`PTH`**: `os.path` → `pathlib.Path` throughout.
- **`TRY400`**: `_LOGGER.error` → `_LOGGER.exception` inside except blocks (better tracebacks).
- **`B007` / `SIM102` / `RET505`** cleanups.

## 2. Flow-translation coverage test (`tests/test_translations.py`)
Drives the real config and options flows, extracts each step's voluptuous field keys, and asserts every field has a `data` label in **both `strings.json` and `translations/en.json`**. This is stricter than HA's rule (which only checks strings.json) and would have caught the plant `moisture_grace_period` gap. Verified it fails on a missing field and passes on the real schemas.

## Testing
**111 tests pass** (109 + 2 new). ruff + black clean across source and tests. Behavior changes (executor wraps, exception logging) covered by the existing config-flow / init / uploader tests.

Next: replicate the same ruff expansion + translation test to `homeassistant-plant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)