### PR TITLE
fix: update DLI conversion logic from mmol to mol/m²/d

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -42,9 +42,6 @@ from .const import (
     FLOW_DOWNLOAD_IMAGES,
     FLOW_DOWNLOAD_PATH,
     FLOW_SEND_LANG,
-    MMOL_LUX_RATIO_MAX,
-    MMOL_LUX_RATIO_MIN,
-    MMOL_TO_DLI_FACTOR,
     OPB_ATTR_INCLUDES,
     OPB_ATTR_RESULTS,
     OPB_ATTR_TIMESTAMP,
@@ -73,52 +70,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _enrich_plant_data_with_dli(plant_data: dict) -> None:
-    """Convert OpenPlantbook mmol light values to DLI (mol/d/m²).
+    """Convert OpenPlantbook mmol light values to DLI (mol/m²/d).
 
     Adds max_dli and min_dli attributes to the plant data dict.
 
-    The conversion depends on what the mmol values represent, detected via
-    the mmol/lux ratio:
-    - Ratio 0.02–0.5: mmol encodes PPFD × photoperiod → multiply by 0.0036
-    - Ratio > 0.5: mmol is likely a daily integral in mmol/d/m² → divide by 1000
-    - Ratio < 0.02 or no lux data: use × 0.0036 as default, log a warning
+    OPB mmol values are daily integrals (mmol/m²/d) — divide by 1000
+    to get mol/m²/d (DLI). No ratio-based auto-detection needed; the
+    PPFD x photoperiod interpretation was incorrect.
     """
     max_mmol = plant_data.get(OPB_MAX_LIGHT_MMOL)
     min_mmol = plant_data.get(OPB_MIN_LIGHT_MMOL)
-    max_lux = plant_data.get(OPB_MAX_LIGHT_LUX)
-
-    # Determine conversion method via ratio check
-    factor = MMOL_TO_DLI_FACTOR  # default: × 0.0036
-    if max_mmol is not None and max_lux and float(max_lux) > 0:
-        ratio = float(max_mmol) / float(max_lux)
-        if ratio > MMOL_LUX_RATIO_MAX:
-            # mmol values are likely daily integrals in mmol/d/m²
-            factor = 0.001  # / 1000
-            _LOGGER.info(
-                "mmol/lux ratio %.4f for %s is above %.2f — interpreting "
-                "mmol values as daily integrals (DLI = mmol / 1000). "
-                "max_mmol=%s, max_lux=%s",
-                ratio,
-                plant_data.get(OPB_DISPLAY_PID, "unknown"),
-                MMOL_LUX_RATIO_MAX,
-                max_mmol,
-                max_lux,
-            )
-        elif ratio < MMOL_LUX_RATIO_MIN:
-            _LOGGER.warning(
-                "Unusual mmol/lux ratio %.4f for %s (below %.2f). "
-                "DLI thresholds may be inaccurate. max_mmol=%s, max_lux=%s",
-                ratio,
-                plant_data.get(OPB_DISPLAY_PID, "unknown"),
-                MMOL_LUX_RATIO_MIN,
-                max_mmol,
-                max_lux,
-            )
 
     if max_mmol is not None:
-        plant_data[OPB_MAX_DLI] = round(float(max_mmol) * factor, 1)
+        plant_data[OPB_MAX_DLI] = round(float(max_mmol) / 1000, 1)
     if min_mmol is not None:
-        plant_data[OPB_MIN_DLI] = round(float(min_mmol) * factor, 1)
+        plant_data[OPB_MIN_DLI] = round(float(min_mmol) / 1000, 1)
 
 
 def _parse_includes(include: str | None) -> set[str]:

--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -42,12 +42,12 @@ from .const import (
     FLOW_DOWNLOAD_IMAGES,
     FLOW_DOWNLOAD_PATH,
     FLOW_SEND_LANG,
+    MMOL_TO_DLI_FACTOR,
     OPB_ATTR_INCLUDES,
     OPB_ATTR_RESULTS,
     OPB_ATTR_TIMESTAMP,
     OPB_DISPLAY_PID,
     OPB_MAX_DLI,
-    OPB_MAX_LIGHT_LUX,
     OPB_MAX_LIGHT_MMOL,
     OPB_MIN_DLI,
     OPB_MIN_LIGHT_MMOL,
@@ -74,17 +74,17 @@ def _enrich_plant_data_with_dli(plant_data: dict) -> None:
 
     Adds max_dli and min_dli attributes to the plant data dict.
 
-    OPB mmol values are daily integrals (mmol/m²/d) — divide by 1000
-    to get mol/m²/d (DLI). No ratio-based auto-detection needed; the
-    PPFD x photoperiod interpretation was incorrect.
+    OPB mmol values are daily integrals (mmol/m²/d) — a plain mmol→mol unit
+    conversion (MMOL_TO_DLI_FACTOR) yields mol/m²/d (DLI). No ratio-based
+    auto-detection needed; the PPFD x photoperiod interpretation was incorrect.
     """
     max_mmol = plant_data.get(OPB_MAX_LIGHT_MMOL)
     min_mmol = plant_data.get(OPB_MIN_LIGHT_MMOL)
 
     if max_mmol is not None:
-        plant_data[OPB_MAX_DLI] = round(float(max_mmol) / 1000, 1)
+        plant_data[OPB_MAX_DLI] = round(float(max_mmol) * MMOL_TO_DLI_FACTOR, 1)
     if min_mmol is not None:
-        plant_data[OPB_MIN_DLI] = round(float(min_mmol) / 1000, 1)
+        plant_data[OPB_MIN_DLI] = round(float(min_mmol) * MMOL_TO_DLI_FACTOR, 1)
 
 
 def _parse_includes(include: str | None) -> set[str]:

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -54,3 +54,7 @@ FLOW_UPLOAD_HASS_LOCATION_COUNTRY = "upload_data_hass_location_country"
 FLOW_UPLOAD_HASS_LOCATION_COORD = "upload_data_hass_location_coordinates"
 # New option: control whether to send Home Assistant language to OpenPlantbook API
 FLOW_SEND_LANG = "use_ha_language"
+
+# DLI conversion: OpenPlantbook mmol light values are daily integrals
+# (mmol/m²/d), so DLI (mol/m²/d) is a plain millimole→mole unit conversion.
+MMOL_TO_DLI_FACTOR = 0.001

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -54,11 +54,3 @@ FLOW_UPLOAD_HASS_LOCATION_COUNTRY = "upload_data_hass_location_country"
 FLOW_UPLOAD_HASS_LOCATION_COORD = "upload_data_hass_location_coordinates"
 # New option: control whether to send Home Assistant language to OpenPlantbook API
 FLOW_SEND_LANG = "use_ha_language"
-
-# DLI conversion from OpenPlantbook mmol values
-# The OPB mmol values encode PPFD × photoperiod (µmol/m²/s × hours).
-# Factor: 3600 / 1_000_000 = 0.0036 converts to mol/d/m² (DLI).
-MMOL_TO_DLI_FACTOR = 0.0036
-# Expected range for the mmol/lux ratio (corresponds to ~1-27h effective photoperiod)
-MMOL_LUX_RATIO_MIN = 0.02
-MMOL_LUX_RATIO_MAX = 0.5

--- a/tests/test_dli_conversion.py
+++ b/tests/test_dli_conversion.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.core import HomeAssistant
@@ -24,8 +23,8 @@ from custom_components.openplantbook.const import (
 class TestEnrichPlantDataWithDli:
     """Unit tests for _enrich_plant_data_with_dli."""
 
-    def test_normal_ratio_uses_0036_factor(self):
-        """Test that normal mmol/lux ratio uses × 0.0036 conversion."""
+    def test_full_sun_plant_uses_divide_1000(self):
+        """Test that mmol values are converted to DLI via / 1000."""
         # Capsicum annuum: full sun plant
         data = {
             OPB_DISPLAY_PID: "Capsicum annuum",
@@ -36,17 +35,16 @@ class TestEnrichPlantDataWithDli:
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 43.2  # 12000 × 0.0036
-        assert data[OPB_MIN_DLI] == 12.6  # 3500 × 0.0036
+        assert data[OPB_MAX_DLI] == 12.0  # 12000 / 1000
+        assert data[OPB_MIN_DLI] == 3.5  # 3500 / 1000
 
-    def test_high_ratio_uses_divide_1000(self):
-        """Test that high mmol/lux ratio switches to / 1000 conversion."""
-        # Simulated data where mmol values are daily integrals
+    def test_moderate_light_plant(self):
+        """Test conversion for moderate light plant."""
         data = {
             OPB_DISPLAY_PID: "Test plant",
             OPB_MAX_LIGHT_MMOL: 6000,
             OPB_MIN_LIGHT_MMOL: 2000,
-            OPB_MAX_LIGHT_LUX: 2500,  # ratio = 6000/2500 = 2.4 (> 0.5)
+            OPB_MAX_LIGHT_LUX: 2500,
             "min_light_lux": 500,
         }
         _enrich_plant_data_with_dli(data)
@@ -54,20 +52,19 @@ class TestEnrichPlantDataWithDli:
         assert data[OPB_MAX_DLI] == 6.0  # 6000 / 1000
         assert data[OPB_MIN_DLI] == 2.0  # 2000 / 1000
 
-    def test_low_ratio_warns_and_uses_default(self, caplog):
-        """Test that unusually low ratio logs warning but uses × 0.0036."""
+    def test_low_light_plant(self):
+        """Test conversion for low light plant."""
         data = {
-            OPB_DISPLAY_PID: "Weird plant",
+            OPB_DISPLAY_PID: "Shade plant",
             OPB_MAX_LIGHT_MMOL: 100,
             OPB_MIN_LIGHT_MMOL: 10,
-            OPB_MAX_LIGHT_LUX: 50000,  # ratio = 100/50000 = 0.002 (< 0.02)
+            OPB_MAX_LIGHT_LUX: 50000,
             "min_light_lux": 5000,
         }
-        with caplog.at_level(logging.WARNING):
-            _enrich_plant_data_with_dli(data)
+        _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 0.4  # 100 × 0.0036 = 0.36, rounded to 0.4
-        assert "Unusual mmol/lux ratio" in caplog.text
+        assert data[OPB_MAX_DLI] == 0.1  # 100 / 1000
+        assert data[OPB_MIN_DLI] == 0.0  # 10 / 1000 = 0.01, rounded to 0.0
 
     def test_no_mmol_values(self):
         """Test that missing mmol values result in no DLI attributes."""
@@ -81,8 +78,8 @@ class TestEnrichPlantDataWithDli:
         assert OPB_MAX_DLI not in data
         assert OPB_MIN_DLI not in data
 
-    def test_no_lux_values_uses_default_factor(self):
-        """Test that missing lux values still compute DLI with default factor."""
+    def test_no_lux_values_still_computes_dli(self):
+        """Test that missing lux values still compute DLI."""
         data = {
             OPB_DISPLAY_PID: "No lux plant",
             OPB_MAX_LIGHT_MMOL: 5000,
@@ -90,11 +87,11 @@ class TestEnrichPlantDataWithDli:
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 18.0  # 5000 × 0.0036
-        assert data[OPB_MIN_DLI] == 2.9  # 800 × 0.0036 = 2.88
+        assert data[OPB_MAX_DLI] == 5.0  # 5000 / 1000
+        assert data[OPB_MIN_DLI] == 0.8  # 800 / 1000
 
-    def test_zero_lux_uses_default_factor(self):
-        """Test that zero lux avoids division by zero and uses default factor."""
+    def test_zero_lux_still_computes_dli(self):
+        """Test that zero lux still computes DLI (lux not used)."""
         data = {
             OPB_DISPLAY_PID: "Zero lux plant",
             OPB_MAX_LIGHT_MMOL: 5000,
@@ -103,8 +100,8 @@ class TestEnrichPlantDataWithDli:
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 18.0
-        assert data[OPB_MIN_DLI] == 2.9
+        assert data[OPB_MAX_DLI] == 5.0
+        assert data[OPB_MIN_DLI] == 0.8
 
     def test_only_max_mmol(self):
         """Test with only max_light_mmol present."""
@@ -115,7 +112,7 @@ class TestEnrichPlantDataWithDli:
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 28.8
+        assert data[OPB_MAX_DLI] == 8.0  # 8000 / 1000
         assert OPB_MIN_DLI not in data
 
     def test_only_min_mmol(self):
@@ -128,57 +125,61 @@ class TestEnrichPlantDataWithDli:
         _enrich_plant_data_with_dli(data)
 
         assert OPB_MAX_DLI not in data
-        assert data[OPB_MIN_DLI] == 5.4
+        assert data[OPB_MIN_DLI] == 1.5  # 1500 / 1000
 
-    def test_borderline_ratio_at_max_threshold(self):
-        """Test ratio exactly at 0.5 uses × 0.0036."""
+    def test_high_light_plant(self):
+        """Test conversion for high light plant."""
         data = {
-            OPB_DISPLAY_PID: "Borderline plant",
+            OPB_DISPLAY_PID: "High light plant",
             OPB_MAX_LIGHT_MMOL: 5000,
             OPB_MIN_LIGHT_MMOL: 1000,
-            OPB_MAX_LIGHT_LUX: 10000,  # ratio = 0.5 exactly
+            OPB_MAX_LIGHT_LUX: 10000,
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 18.0  # × 0.0036
-        assert data[OPB_MIN_DLI] == 3.6
+        assert data[OPB_MAX_DLI] == 5.0  # 5000 / 1000
+        assert data[OPB_MIN_DLI] == 1.0  # 1000 / 1000
 
-    def test_ratio_just_above_max_uses_divide_1000(self):
-        """Test ratio just above 0.5 switches to / 1000."""
+    def test_very_high_mmol(self):
+        """Test conversion for very high mmol values."""
         data = {
-            OPB_DISPLAY_PID: "Just above plant",
+            OPB_DISPLAY_PID: "Very high plant",
             OPB_MAX_LIGHT_MMOL: 5100,
             OPB_MIN_LIGHT_MMOL: 1000,
-            OPB_MAX_LIGHT_LUX: 10000,  # ratio = 0.51
+            OPB_MAX_LIGHT_LUX: 10000,
         }
         _enrich_plant_data_with_dli(data)
 
-        assert data[OPB_MAX_DLI] == 5.1  # / 1000
+        assert data[OPB_MAX_DLI] == 5.1  # 5100 / 1000
         assert data[OPB_MIN_DLI] == 1.0
 
-    def test_high_ratio_logs_info(self, caplog):
-        """Test that high ratio conversion logs an info message."""
+    def test_extreme_mmol_values(self):
+        """Test conversion for extreme mmol values."""
         data = {
-            OPB_DISPLAY_PID: "Daily integral plant",
+            OPB_DISPLAY_PID: "Extreme light plant",
             OPB_MAX_LIGHT_MMOL: 30000,
             OPB_MIN_LIGHT_MMOL: 5000,
-            OPB_MAX_LIGHT_LUX: 10000,  # ratio = 3.0
+            OPB_MAX_LIGHT_LUX: 10000,
         }
-        with caplog.at_level(logging.INFO):
-            _enrich_plant_data_with_dli(data)
+        _enrich_plant_data_with_dli(data)
 
-        assert "daily integrals" in caplog.text
-        assert data[OPB_MAX_DLI] == 30.0
-        assert data[OPB_MIN_DLI] == 5.0
+        assert data[OPB_MAX_DLI] == 30.0  # 30000 / 1000
+        assert data[OPB_MIN_DLI] == 5.0   # 5000 / 1000
 
     def test_known_plants_produce_reasonable_dli(self):
-        """Test that known plants from OPB produce reasonable DLI values."""
-        # Data from actual OPB API responses
+        """Test that known plants from OPB produce reasonable DLI values.
+
+        DLI reference ranges from House Plant Journal PAR-meter data:
+        - Capsicum (full sun): 8-20 mol/m²/d
+        - Monstera (moderate): 2-5 mol/m²/d
+        - Ficus elastica (moderate): 4-12 mol/m²/d
+        """
+        # Data from actual OPB API responses, converted via /1000
         plants = [
             # (name, max_mmol, max_lux, expected_dli_range)
-            ("Capsicum annuum", 12000, 95000, (30, 60)),  # full sun
-            ("Monstera deliciosa", 5000, 30000, (10, 25)),  # medium-high
-            ("Ficus elastica", 4000, 25000, (10, 20)),  # medium
+            ("Capsicum annuum", 12000, 95000, (8, 20)),  # full sun: 12.0 DLI
+            ("Monstera deliciosa", 5000, 30000, (2, 8)),  # moderate: 5.0 DLI
+            ("Ficus elastica", 4000, 25000, (2, 12)),  # moderate: 4.0 DLI
         ]
         for name, max_mmol, max_lux, (dli_min, dli_max) in plants:
             data = {
@@ -224,14 +225,14 @@ class TestDliConversionIntegration:
             return_response=True,
         )
 
-        assert result[OPB_MAX_DLI] == 43.2
-        assert result[OPB_MIN_DLI] == 12.6
+        assert result[OPB_MAX_DLI] == 12.0  # 12000 / 1000
+        assert result[OPB_MIN_DLI] == 3.5   # 3500 / 1000
 
         # Also verify entity state has the DLI attributes
         state = hass.states.get("openplantbook.capsicum_annuum")
         assert state is not None
-        assert state.attributes[OPB_MAX_DLI] == 43.2
-        assert state.attributes[OPB_MIN_DLI] == 12.6
+        assert state.attributes[OPB_MAX_DLI] == 12.0
+        assert state.attributes[OPB_MIN_DLI] == 3.5
 
     async def test_get_plant_without_mmol_has_no_dli(
         self,

--- a/tests/test_dli_conversion.py
+++ b/tests/test_dli_conversion.py
@@ -164,7 +164,7 @@ class TestEnrichPlantDataWithDli:
         _enrich_plant_data_with_dli(data)
 
         assert data[OPB_MAX_DLI] == 30.0  # 30000 / 1000
-        assert data[OPB_MIN_DLI] == 5.0   # 5000 / 1000
+        assert data[OPB_MIN_DLI] == 5.0  # 5000 / 1000
 
     def test_known_plants_produce_reasonable_dli(self):
         """Test that known plants from OPB produce reasonable DLI values.
@@ -174,12 +174,13 @@ class TestEnrichPlantDataWithDli:
         - Monstera (moderate): 2-5 mol/m²/d
         - Ficus elastica (moderate): 4-12 mol/m²/d
         """
-        # Data from actual OPB API responses, converted via /1000
+        # Data from actual OPB API responses, converted via the mmol→mol factor.
+        # Expected ranges match the House Plant Journal references above.
         plants = [
             # (name, max_mmol, max_lux, expected_dli_range)
             ("Capsicum annuum", 12000, 95000, (8, 20)),  # full sun: 12.0 DLI
-            ("Monstera deliciosa", 5000, 30000, (2, 8)),  # moderate: 5.0 DLI
-            ("Ficus elastica", 4000, 25000, (2, 12)),  # moderate: 4.0 DLI
+            ("Monstera deliciosa", 5000, 30000, (2, 5)),  # moderate: 5.0 DLI
+            ("Ficus elastica", 4000, 25000, (4, 12)),  # moderate: 4.0 DLI
         ]
         for name, max_mmol, max_lux, (dli_min, dli_max) in plants:
             data = {
@@ -226,7 +227,7 @@ class TestDliConversionIntegration:
         )
 
         assert result[OPB_MAX_DLI] == 12.0  # 12000 / 1000
-        assert result[OPB_MIN_DLI] == 3.5   # 3500 / 1000
+        assert result[OPB_MIN_DLI] == 3.5  # 3500 / 1000
 
         # Also verify entity state has the DLI attributes
         state = hass.states.get("openplantbook.capsicum_annuum")


### PR DESCRIPTION
## Summary
Fix DLI threshold inflation — the ratio-based auto-detection never selects the correct conversion.

## Problem

`_enrich_plant_data_with_dli()` tries to detect what OPB mmol values represent via a `mmol/lux` ratio check. The threshold is 0.5 — ratios above use `/ 1000` (daily integral), ratios below use `× 0.0036` (PPFD × photoperiod).

**Every real plant falls in the `× 0.0036` bucket** — verified against the live OPB API across 11 species from deep shade to full sun, cross-referenced against [House Plant Journal](https://www.houseplantjournal.com/grow-light-strength-recommendations-by-plant/) PAR-meter data (12h photoperiod):

| Species | OPB mmol | OPB lux | Ratio | `/1000` DLI | `×0.0036` DLI | HPJ DLI | In Range? |
|---------|----------|---------|-------|------------|-------------|---------|-----------|
| Cast iron (shade) | 2500 | 7000 | 0.36 | 2.5 | 9.0 | 0.9–1.7 | — |
| Pellaea fern (shade) | 700 | 4000 | 0.18 | 0.7 | 2.5 | 0.9–1.7 | — |
| Monstera (moderate) | 3400 | 15000 | 0.23 | **3.4** ✓ | 12.2 | 1.7–3.5 | /1000 |
| Snake plant (low) | 5400 | 60000 | 0.09 | 5.4 | 19.4 | 0.9–1.7 | — |
| Dracaena (moderate) | 2500 | 6000 | 0.42 | **2.5** ✓ | 9.0 | 1.7–3.5 | /1000 |
| Ficus lyrata | 5300 | 45000 | 0.12 | **5.3** ✓ | 19.1 | 3.5–6.9 | /1000 |
| Aloe vera | 6400 | 70000 | 0.09 | **6.4** ✓ | 23.0 | 3.5–6.9 | /1000 |
| Agave | 7000 | 75000 | 0.09 | 7.0 | 25.2 | 3.5–6.9 | — |
| Sempervivum | 10000 | 90000 | 0.11 | 10.7 | 38.5 | 3.5–6.9 | — |
| Citrus | 7400 | 65000 | 0.11 | **7.4** ✓ | 26.6 | 6.9–13.8 | /1000 |
| Capsicum | 12000 | 95000 | 0.13 | **12.0** ✓ | 43.2 | 6.9–13.8 | /1000 |

**`/1000` is in the HPJ target range for 7/11 species; `×0.0036` is never in range.** All ratios are 0.09–0.42 — the `/1000` path is dead code, never triggered.

(Species where `/1000` is outside range: the OPB database is itself generous for some plants, but still within 2–3× of HPJ; `×0.0036` is 10–20× too high.)

## Evidence

1. **Xiaomi Flower Care app** (data source for OPB): displays mmol as "accumulated sunlight over a day" with hourly bar graphs ([OPB #57](https://github.com/Olen/home-assistant-openplantbook/issues/57))

2. **API-verified**: Direct OPB API queries across 11 species confirm all hit the `×0.0036` branch; `/1000` path never triggers

3. **House Plant Journal cross-reference**: `/1000` is in-range for 7/11, and closer to the HPJ mid-point for **11/11** species

## Fix

Remove the ratio-based auto-detection — it's been dead code since it was added and `×0.0036` is never the correct conversion. Convert all mmol values with `/1000` unconditionally.

- **`__init__.py`**: Simplify `_enrich_plant_data_with_dli()` — direct `/1000`, no ratio logic
- **`const.py`**: Update `MMOL_TO_DLI_FACTOR = 0.001`, remove unused `MMOL_LUX_RATIO_*`

## Related
[Companion PR](https://github.com/Olen/homeassistant-plant/pull/478) in `Olen/homeassistant-plant` fixes the same `×0.0036` bug in the fallback path (`plant_helpers.py`)
