### PR TITLE
feat: clamp converted DLI to the physical maximum

### DIFF
--- a/custom_components/openplantbook/__init__.py
+++ b/custom_components/openplantbook/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     DATA_COMPONENT,
     DATA_SEARCH_ENTITY,
     DATA_SPECIES_ENTITIES,
+    DLI_SANITY_MAX,
     DOMAIN,
     FLOW_DOWNLOAD_IMAGES,
     FLOW_DOWNLOAD_PATH,
@@ -77,14 +78,44 @@ def _enrich_plant_data_with_dli(plant_data: dict) -> None:
     OPB mmol values are daily integrals (mmol/m²/d) — a plain mmol→mol unit
     conversion (MMOL_TO_DLI_FACTOR) yields mol/m²/d (DLI). No ratio-based
     auto-detection needed; the PPFD x photoperiod interpretation was incorrect.
+
+    The result is clamped to the physical maximum DLI: OPB aggregates loosely
+    validated, multi-source data, so a stray unit mix-up could otherwise yield
+    a biologically impossible threshold.
     """
+    pid = plant_data.get(OPB_DISPLAY_PID, "unknown")
     max_mmol = plant_data.get(OPB_MAX_LIGHT_MMOL)
     min_mmol = plant_data.get(OPB_MIN_LIGHT_MMOL)
 
     if max_mmol is not None:
-        plant_data[OPB_MAX_DLI] = round(float(max_mmol) * MMOL_TO_DLI_FACTOR, 1)
+        plant_data[OPB_MAX_DLI] = _clamp_dli(
+            round(float(max_mmol) * MMOL_TO_DLI_FACTOR, 1), "max", pid
+        )
     if min_mmol is not None:
-        plant_data[OPB_MIN_DLI] = round(float(min_mmol) * MMOL_TO_DLI_FACTOR, 1)
+        plant_data[OPB_MIN_DLI] = _clamp_dli(
+            round(float(min_mmol) * MMOL_TO_DLI_FACTOR, 1), "min", pid
+        )
+
+
+def _clamp_dli(value: float, bound: str, pid: str) -> float:
+    """Clamp a converted DLI to the physical maximum, warning if exceeded.
+
+    Only an upper guard is applied: terrestrial DLI cannot exceed ~65 mol/m²/d,
+    so a higher value signals suspect OPB data. There is deliberately no lower
+    guard — legitimate deep-shade species have minimums that round toward 0, and
+    clamping those would corrupt valid data.
+    """
+    if value > DLI_SANITY_MAX:
+        _LOGGER.warning(
+            "%s DLI %s mol/m²/d for %s exceeds the plausible maximum %s; "
+            "clamping (check the OpenPlantbook source data)",
+            bound,
+            value,
+            pid,
+            DLI_SANITY_MAX,
+        )
+        return DLI_SANITY_MAX
+    return value
 
 
 def _parse_includes(include: str | None) -> set[str]:

--- a/custom_components/openplantbook/const.py
+++ b/custom_components/openplantbook/const.py
@@ -58,3 +58,10 @@ FLOW_SEND_LANG = "use_ha_language"
 # DLI conversion: OpenPlantbook mmol light values are daily integrals
 # (mmol/m²/d), so DLI (mol/m²/d) is a plain millimole→mole unit conversion.
 MMOL_TO_DLI_FACTOR = 0.001
+
+# Physical ceiling for DLI (mol/m²/d): ~65 is the maximum daily light integral
+# attainable at Earth's surface (full tropical sun, clear sky, long day).
+# OpenPlantbook aggregates loosely validated, multi-source data; a converted
+# value above this is biologically impossible and signals suspect data, so it
+# is clamped. No lower guard: legitimate deep-shade minimums round toward 0.
+DLI_SANITY_MAX = 65.0

--- a/tests/test_dli_conversion.py
+++ b/tests/test_dli_conversion.py
@@ -7,8 +7,9 @@ from unittest.mock import AsyncMock, MagicMock
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.openplantbook import _enrich_plant_data_with_dli
+from custom_components.openplantbook import _clamp_dli, _enrich_plant_data_with_dli
 from custom_components.openplantbook.const import (
+    DLI_SANITY_MAX,
     DOMAIN,
     OPB_DISPLAY_PID,
     OPB_MAX_DLI,
@@ -192,6 +193,38 @@ class TestEnrichPlantDataWithDli:
             assert (
                 dli_min <= data[OPB_MAX_DLI] <= dli_max
             ), f"{name}: max_dli={data[OPB_MAX_DLI]} not in range {dli_min}-{dli_max}"
+
+
+class TestDliSanityClamp:
+    """Tests for the DLI sanity clamp on converted values."""
+
+    def test_value_in_band_unchanged(self):
+        """A plausible DLI passes through untouched."""
+        assert _clamp_dli(12.0, "max", "Capsicum annuum") == 12.0
+        assert _clamp_dli(0.7, "min", "Pellaea rotundifolia") == 0.7
+
+    def test_near_zero_minimum_not_clamped(self):
+        """Legitimate deep-shade minimums (rounding toward 0) are preserved."""
+        assert _clamp_dli(0.0, "min", "Pellaea rotundifolia") == 0.0
+
+    def test_clamps_impossible_high_value(self, caplog):
+        """A value above Earth's physical max DLI is clamped + warned."""
+        result = _clamp_dli(120.0, "max", "Corrupt entry")
+        assert result == DLI_SANITY_MAX
+        assert "exceeds the plausible maximum" in caplog.text
+
+    def test_enrich_clamps_absurd_mmol(self, caplog):
+        """End-to-end: an absurd max_light_mmol yields a clamped DLI."""
+        # 100000000 mmol would be 100000 mol/m²/d — clearly corrupt source data.
+        data = {
+            OPB_DISPLAY_PID: "Corrupt entry",
+            OPB_MAX_LIGHT_MMOL: 100000000,
+            OPB_MIN_LIGHT_MMOL: 2000,
+        }
+        _enrich_plant_data_with_dli(data)
+        assert data[OPB_MAX_DLI] == DLI_SANITY_MAX
+        assert data[OPB_MIN_DLI] == 2.0  # normal value untouched
+        assert "exceeds the plausible maximum" in caplog.text
 
 
 class TestDliConversionIntegration:


### PR DESCRIPTION
## Summary
Follow-up hardening on top of #91. Guards against suspect OpenPlantbook source data producing biologically impossible DLI thresholds.

## Why
OPB aggregates loosely validated, multi-source data. After #91 converts `mmol → mol/m²/d`, a stray unit mix-up (or an inflated value from an older client) could still yield an absurd threshold. Validated against a 60-species sample from the live OPB API: the `/1000` conversion is consistent and lands every species in a plausible band, but the un-sampled long tail of the database warrants a cheap guard.

## What
- Clamp converted DLI to `DLI_SANITY_MAX = 65.0` mol/m²/d — the maximum daily light integral attainable at Earth's surface — and log a warning when it fires.
- **Upper guard only.** A lower guard was deliberately omitted: legitimate deep-shade minimums round toward 0, so clamping the low end would corrupt valid data (this is the design correction that keeps #91's `test_low_light_plant` valid).

## Tests
New `TestDliSanityClamp`: pass-through, near-zero minimum preserved, impossible-high clamp + warning, and end-to-end clamp via `_enrich_plant_data_with_dli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)